### PR TITLE
Fix bug with out-of-time production switches

### DIFF
--- a/app/components/inputProdSettings.tsx
+++ b/app/components/inputProdSettings.tsx
@@ -65,7 +65,7 @@ export default function ModalProdSettings({closeModal, currentProdSettings, curr
 function getInitSettingsForModal(currentProdSettings : T_ProductionSettings, currentSwitches : T_SwitchAction[])
     : T_ProductionSettings {
 
-    let result = deepCopy(defaultProductionSettings);
+    let result : T_ProductionSettings = deepCopy(defaultProductionSettings);
     for(const [k, v] of Object.entries(currentProdSettings)){
         let idx = currentSwitches.findIndex(ele => ele.key === k);
         let newValue = v;

--- a/app/components/planner.tsx
+++ b/app/components/planner.tsx
@@ -63,12 +63,12 @@ export default function Planner({timeIdGroups, gameState, actions, setActions, o
         : void {
 
         if(modalProdSwitchData === null){
-            console.log("error: modalProdSwitchData is null, so production settings can't be updated");
             return;
         }
 
         let workingActions : T_Action[] = deepCopy(actions);
         let numInternalSwitches = 0;
+
         if(modalProdSwitchData.switches.length > 0){
             workingActions = removeAllSwitchActionsInTimeGroup({ timeGroupData: modalProdSwitchData, workingActions });
             numInternalSwitches = countInternalProductionSwitches({ timeGroupData: modalProdSwitchData });
@@ -220,12 +220,13 @@ interface I_PlannerModals extends
     Pick<I_Planner, "gameState" | "purchaseData">{
     upgradePickerProps : T_PropsUpgradePickerModal,
     middleProdSwitcherProps : T_PropsMiddleProdSwitcherModal,
-    topProdSwitcherProps : T_PropsTopProdSwitcherModal
+    topProdSwitcherProps : T_PropsTopProdSwitcherModal,
 }
 
 function PlannerModals({ purchaseData, gameState, upgradePickerProps, middleProdSwitcherProps: middleSwitcher, topProdSwitcherProps: topSwitcher } 
     : I_PlannerModals) 
     : JSX.Element | null{
+
 
     return upgradePickerProps.showModal ?
             <UpgradePicker 

--- a/app/components/sectionOfflinePeriods.tsx
+++ b/app/components/sectionOfflinePeriods.tsx
@@ -22,7 +22,7 @@ export default function SectionOfflinePeriods({offlinePeriods, openModal, gameSt
     }
 
     return  <SectionToggled title={"Offline Periods"}>
-                <div className={'overflow-y-auto overflow-x-hidden max-h-[calc(100vh-10rem)] px-2'}>
+                <div className={'overflow-y-auto overflow-x-hidden max-h-[calc(100vh-5rem)] px-2'}>
                     <OfflineDisplay offlinePeriods={offlinePeriods} gameState={gameState} openForm={openModal} idxEdit={idxEdit} />
                     <EditButtonBox openEditForm={() => openModal(null)} label={`+${nbsp()}more`} />
                 </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -104,7 +104,7 @@ export default function Home() {
   useEffect(() => {
     let planAndSwitchData = getPlanData({ gameState, actions, offlinePeriods, prodSettingsAtTop });
     if(planAndSwitchData === null){
-      return
+      return;
     }
 
     setPurchaseData(planAndSwitchData.purchaseData);
@@ -115,6 +115,7 @@ export default function Home() {
   if(purchaseData === undefined || switchData === undefined){
     return null;
   }
+
   const timeIdGroups : T_TimeGroup[] = groupByTimeId({purchaseData, switchData});
 
   return (

--- a/app/utils/getPlanData.tsx
+++ b/app/utils/getPlanData.tsx
@@ -38,7 +38,12 @@ export default function getPlanData({ gameState, actions, offlinePeriods, prodSe
     for(let idx = 0; idx < actions.length; idx++){
 
         let loopAction = actions[idx];
-        if(loopAction.type === 'switch' && timeId < OUT_OF_TIME){
+        if(loopAction.type === 'switch'){
+
+            if(timeId >= OUT_OF_TIME){
+                continue;
+            }
+
             if('to' in loopAction){
                 let switchObject = {
                     key: loopAction.key,
@@ -292,17 +297,6 @@ function advanceWithTwoProdRates({levels, premiumInfo, productionSettings, stock
     return advanceWithTwoProdRates;  
 }
 
-
-// interface I_AdvanceToTime extends 
-//     Pick<I_BuyUpgrade, "levels" | "offlinePeriods" | "premiumInfo" | "productionSettings" | "stockpiles" | "timeId" | "startedAt"> {
-//     eggKey : string, 
-//     eggQty : number, 
-// }
-
-// type T_OutputAdvanceToPurchaseTime = {
-//     timeReady : number,
-//     stockpilesAtTimeReady: T_Stockpiles
-// }
 
 interface I_AdvanceToTimeID extends Pick<I_AdvanceToTime, "stockpiles" | "levels" | "premiumInfo" | "productionSettings"> {
     timeIdStart : number,


### PR DESCRIPTION
Problem:
Switching production didn't work under some conditions.

Cause:
In getPlanData, the if statement controlling flow to the block for processing switch actions was performing two checks: that this action is a switch action and that it was within time.

When a switch action wasn't in time it would fail that check and incorrectly flow into upgrade processing. Since it wasn't an upgrade action, this failed and the function returned null. If getPlanData returns null, the state is not updated. Hence, the switch update "not working".

For some reason, this bug only showed itself when the user adjusted production such that there was 0 production of a needed resource.