### PR TITLE
Refactor game status form to have multiple pages

### DIFF
--- a/app/components/inputGameState_general.tsx
+++ b/app/components/inputGameState_general.tsx
@@ -1,0 +1,272 @@
+import { useState, Dispatch, SetStateAction } from "react";
+
+import { T_GameState, T_TimeRemainingDHM } from "../utils/types";
+
+import { MAX_DAYS } from '../utils/consts';
+import { getDateDisplayStr } from '../utils/dateAndTimeHelpers';
+import { capitalise } from '../utils/formatting';
+
+import Select from './select';
+import { Button } from './buttons';
+import { InputPageWrapper, FormRow, Label, formatValueStr, getUpgradeOptions, InputNumberAsText, GAMESTATE_LABEL_CSS_FORMATTING } from "./inputGameState"
+
+
+interface I_InputGeneral extends I_TimeRemainingFieldset, I_Entered {
+    isVisible : boolean,
+    gameState : T_GameState, 
+    handleLevelChange : (e : React.ChangeEvent<HTMLSelectElement>) => void, 
+    hasAdBoost : boolean, 
+    toggleAdBoost : () => void,
+}
+export default function InputGeneral({isVisible, timeRemaining, setTimeRemaining, timeEntered, setStateOnChange, setTimeEntered, gameState, handleLevelChange, hasAdBoost, toggleAdBoost } 
+    : I_InputGeneral)
+    : JSX.Element {
+
+    return  <InputPageWrapper isVisible={isVisible} heading={"Times and Premium"}>
+        <div>
+                <FormRow extraCSS={"flex gap-2"}>
+                    <TimeRemainingFieldset timeRemaining={timeRemaining} setTimeRemaining={setTimeRemaining} />
+                </FormRow>
+                <FormRow extraCSS={"flex gap-2 items-center"}>
+                    <Entered timeEntered={timeEntered} setStateOnChange={setStateOnChange} setTimeEntered={setTimeEntered}/>
+                </FormRow>
+                <FormRow extraCSS={"flex gap-2"}>
+                    <Select labelExtraCSS={GAMESTATE_LABEL_CSS_FORMATTING} selectExtraCSS={undefined} id={"id_AllEggs"} labelDisplay={"All Eggs"} initValue={gameState === null ? undefined : formatValueStr("All", gameState.premiumInfo.allEggs)} options={getUpgradeOptions({ name: "All", max: 5 })} handleChange={handleLevelChange} />
+                </FormRow>
+                <FormRow extraCSS={"flex gap-2"}>
+                    <Label htmlFor={"id_adBoost"}>Ad Boost</Label>
+                    <input type="checkbox" id="id_adBoost" checked={hasAdBoost} onChange={ toggleAdBoost } />
+                </FormRow>
+                </div>
+            </InputPageWrapper>
+}
+
+
+interface I_Entered {
+    timeEntered : Date | null, 
+    setStateOnChange : (e : React.ChangeEvent<any>, setFunction : Dispatch<SetStateAction<any>>) => void, 
+    setTimeEntered : Dispatch<SetStateAction<Date>>
+}
+function Entered({timeEntered, setStateOnChange, setTimeEntered} 
+    : I_Entered)
+    : JSX.Element {
+
+    timeEntered = timeEntered ?? new Date();
+
+    return(
+        <>
+            <Label htmlFor={"id_timeEntered"}>Entered</Label>
+            <p suppressHydrationWarning={true}>{ getDateDisplayStr(timeEntered) }</p>
+            <input hidden type="datetime-local" id={"id_timeEntered"} value={timeEntered == null ? "" : `${timeEntered}`} onChange={(e) => setStateOnChange(e, setTimeEntered)}/>
+
+            <Button 
+                htmlType={"button"}
+                onClick={() => { setTimeEntered(new Date()) }}
+                colours={"secondary"}
+                size={"inline"}
+                extraCSS={"ml-3"}
+            >
+                &laquo;&nbsp;now
+            </Button>
+        </>
+    )
+}
+
+
+interface I_TimeRemainingFieldset {
+    timeRemaining: T_TimeRemainingDHM,
+    setTimeRemaining: React.Dispatch<React.SetStateAction<T_TimeRemainingDHM>>
+}
+function TimeRemainingFieldset({timeRemaining, setTimeRemaining} 
+    : I_TimeRemainingFieldset)
+    : JSX.Element {
+
+    const { isError, message, handleChangeDays, handleChangeHours, handleChangeMinutes } = useTimeRemainingFieldset({timeRemaining, setTimeRemaining});
+
+    return (
+        <fieldset className={"relative w-full pt-5" + " " + ""}>
+            <legend className={"absolute top-0 mb-2" + " " + GAMESTATE_LABEL_CSS_FORMATTING}>Remaining</legend>
+            <div className={'relative flex flex-col items-center gap-1 px-3 ml-1 mt-2'}>
+                <div className={'flex justify-center gap-2 mt-1'}>
+                    <TimeRemainingUnit unitName={"days"} value={timeRemaining == null ? 0 : timeRemaining.days} handleChange={handleChangeDays} />
+                    <TimeRemainingUnit unitName={"hours"} value={timeRemaining == null ? 0 : timeRemaining.hours} handleChange={handleChangeHours} />
+                    <TimeRemainingUnit unitName={"minutes"} value={timeRemaining == null ? 0 : timeRemaining.minutes} handleChange={handleChangeMinutes} />
+                </div>
+                { isError ?
+                    <div className={"text-xs border-1 text-neutral-700 px-1 py-1 w-56"}>{capitalise(message)}</div>
+                    : null
+                }
+            </div>
+        </fieldset>
+    )
+}
+
+interface I_TimeRemainingUnitProps {
+    unitName : string, 
+    value : number, 
+    handleChange : (e : React.ChangeEvent<HTMLInputElement>) => void
+}
+function TimeRemainingUnit({unitName, value, handleChange} 
+    : I_TimeRemainingUnitProps)
+    : JSX.Element {
+
+    if(isNaN(value)){
+        value = 0;
+    }
+
+    const idStr = `id_${unitName}`;
+    return (
+        <div className={'flex items-center'}>
+            <InputNumberAsText cssStr={"w-12 pl-1"} idStr={idStr} value={value} handleChange={handleChange} />
+            <label className={"pl-1 pr-2"} htmlFor={idStr}>{unitName.charAt(0)}</label>
+        </div>
+    )
+}
+
+
+type T_OutputUseTimeRemainingFieldset = {
+    isError : boolean, 
+    message : string, 
+    handleChangeDays : (e : React.ChangeEvent<HTMLInputElement>) => void, 
+    handleChangeHours : (e : React.ChangeEvent<HTMLInputElement>) => void, 
+    handleChangeMinutes : (e : React.ChangeEvent<HTMLInputElement>) => void, 
+}
+
+function useTimeRemainingFieldset({timeRemaining, setTimeRemaining}
+    : I_TimeRemainingFieldset)
+    : T_OutputUseTimeRemainingFieldset {
+
+    const [isError, setIsError] = useState(false);
+    const [message, setMessage] = useState("");
+
+    const MAX_HOURS = 23;
+    const MAX_MINUTES = 59;
+
+    function handleChangeDays(e : React.ChangeEvent<HTMLInputElement>){
+        let newDaysStr = e.target.value;
+        let newDays = parseInt(newDaysStr);
+
+        newDays = validateDays(newDays);
+
+        if(newDays === MAX_DAYS){
+            setTimeRemaining({
+                days: MAX_DAYS,
+                hours: 0,
+                minutes: 0
+            });
+            return;
+        }
+
+        setTimeRemaining(prev => {
+            return {
+                ...prev,
+                days: newDays
+            }
+        });
+    }
+
+    function validateDays(newDays : number){
+        const rangeStr = `days can be 0 - ${MAX_DAYS}`;
+
+        if(newDays > MAX_DAYS){
+            setMessage(rangeStr);
+            setIsError(true);
+            newDays = MAX_DAYS;
+        }
+        else if(newDays === MAX_DAYS 
+                && ( timeRemaining.hours > 0 || timeRemaining.minutes > 0)
+            ){
+            setIsError(true);
+            setMessage(`${MAX_DAYS} days is the maximum: hours and minutes set to 0`);
+        }
+        else if(newDays < 0){
+            setIsError(true);
+            setMessage(rangeStr);
+            newDays = 0;
+        }
+        else if(isError){
+            setIsError(false);
+        }
+
+        return newDays;
+    }
+
+
+    function handleChangeHours(e: React.ChangeEvent<HTMLInputElement>){
+        let newHoursStr = e.target.value;
+        let newHours = parseInt(newHoursStr);
+        newHours = validateHours(newHours);
+
+        setTimeRemaining((prev) => {
+            return {
+                ...prev,
+                hours: newHours
+            }
+        });
+    }
+
+    function validateHours(newHours : number){
+        const rangeStr = `hours can be 0 - ${MAX_HOURS} (inclusive)`;
+
+        if(timeRemaining.days === MAX_DAYS && newHours !== 0){
+            setIsError(true);
+            setMessage(`can't go above ${MAX_DAYS} days`);
+            newHours = 0;
+        }
+        else if(newHours > MAX_HOURS){
+            setIsError(true);
+            setMessage(rangeStr);
+            newHours = MAX_HOURS;
+        }
+        else if(newHours < 0){
+            setIsError(true);
+            setMessage(rangeStr);
+            newHours = 0;
+        }
+        else{
+            setIsError(false);
+        }
+
+        return newHours;
+    }
+
+
+    function handleChangeMinutes(e: React.ChangeEvent<HTMLInputElement>){
+        let newMinutesStr = e.target.value;
+        let newMinutes = parseInt(newMinutesStr);
+        newMinutes = validateMinutes(newMinutes);
+
+        setTimeRemaining((prev) => {
+            return {
+                ...prev,
+                minutes: newMinutes
+            }
+        });
+    }
+
+
+    function validateMinutes(newMinutes : number){
+        const rangeStr = `minutes can be 0 - ${MAX_MINUTES}`;
+        if(timeRemaining.days === MAX_DAYS && newMinutes !== 0){
+            setIsError(true);
+            setMessage(`can't go above ${MAX_DAYS} days`);
+            newMinutes = 0;
+        }
+        else if(newMinutes > MAX_MINUTES){
+            setIsError(true);
+            setMessage(rangeStr);
+            newMinutes = MAX_MINUTES;
+        }
+        else if(newMinutes < 0){
+            setIsError(true);
+            setMessage(rangeStr);
+            newMinutes = 0;
+        }
+        else{
+            setIsError(false);
+        }
+        return newMinutes;
+    }
+
+    return { isError, message, handleChangeDays, handleChangeHours, handleChangeMinutes }
+}

--- a/app/components/inputGameState_levelsOther.tsx
+++ b/app/components/inputGameState_levelsOther.tsx
@@ -1,0 +1,85 @@
+import { T_GameState, T_Levels } from "../utils/types";
+import {InputPageWrapper, FormSubHeading, LevelsWrapper, UnitLevelInput, getInitValueForLevelSelect, getUpgradeOptions } from "./inputGameState";
+
+interface I_InputLevelsOther {
+    isVisible : boolean,
+    gameState : T_GameState,
+    levels : T_Levels,
+    handleLevelChange : (e : React.ChangeEvent<HTMLSelectElement>) => void, 
+}
+
+export default function InputLevelsOther({isVisible, gameState, levels, handleLevelChange} 
+    : I_InputLevelsOther)
+    : JSX.Element {
+
+    const speedOptions = [
+        {valueStr: "Speed_0", displayStr: "0%"},
+        {valueStr: "Speed_1", displayStr: "-5%"},
+        {valueStr: "Speed_2", displayStr: "-10%"},
+        {valueStr: "Speed_3", displayStr: "-15%"},
+        {valueStr: "Speed_4", displayStr: "-20%"},
+        {valueStr: "Speed_5", displayStr: "-25%"},
+    ]
+    
+    const dustOptions = [
+        {valueStr: "Dust_0", displayStr: "0%"},
+        {valueStr: "Dust_1", displayStr: "25%"},
+        {valueStr: "Dust_2", displayStr: "50%"},
+        {valueStr: "Dust_3", displayStr: "75%"},
+        {valueStr: "Dust_4", displayStr: "100%"},
+        {valueStr: "Dust_5", displayStr: "125%"},
+        {valueStr: "Dust_6", displayStr: "150%"},
+    ]
+    
+    const productionUpgrades = [
+        { id: "id_Blue", labelDisplay: "Blue", optionsProps: { name: "Blue", max: 4 }},
+        { id: "id_Green", labelDisplay: "Green", optionsProps: { name: "Green", max: 3 }},
+        { id: "id_Red", labelDisplay: "Red", optionsProps: { name: "Red", max: 2 }},
+        { id: "id_Yellow", labelDisplay: "Yellow", optionsProps: { name: "Yellow", max: 1 }},
+    ]
+
+
+    return  <InputPageWrapper isVisible={isVisible} heading={undefined}>
+                <FormSubHeading text={"Egg Levels"} />
+                <LevelsWrapper>
+                    { productionUpgrades.map((ele, idx) => {
+                            let initValue : string | undefined  = getInitValueForLevelSelect(ele.optionsProps.name, gameState);
+                            let keyName = ele.optionsProps.name.toLowerCase();
+                            return <UnitLevelInput key={ele.id} 
+                                        keyName={keyName} 
+                                        idStr={ele.id} 
+                                        labelStr={ele.labelDisplay} 
+                                        initValue={initValue}
+                                        options={getUpgradeOptions(ele.optionsProps)} 
+                                        handleLevelChange={handleLevelChange} 
+                                        currentValue={levels[keyName as keyof typeof levels]}
+                                    />
+                        })
+                    }
+                </LevelsWrapper>
+
+                <FormSubHeading text={"Buff Levels"} />
+                <LevelsWrapper>
+                    <UnitLevelInput
+                        keyName={"speed"} 
+                        idStr={"id_speed"} 
+                        labelStr={"Speed"} 
+                        initValue={gameState === null ? undefined : speedOptions[gameState.levels.speed].valueStr}
+                        options={speedOptions} 
+                        handleLevelChange={handleLevelChange} 
+                        currentValue={levels.speed}
+                    />
+                    <UnitLevelInput
+                        keyName={"dust"} 
+                        idStr={"id_dust"} 
+                        labelStr={"Dust"} 
+                        initValue={gameState === null ? undefined : dustOptions[gameState.levels.dust].valueStr}
+                        options={dustOptions} 
+                        handleLevelChange={handleLevelChange} 
+                        currentValue={levels.dust}
+                    />
+                </LevelsWrapper>
+            </InputPageWrapper>
+
+}
+

--- a/app/components/inputGameState_levelsWorkers.tsx
+++ b/app/components/inputGameState_levelsWorkers.tsx
@@ -1,0 +1,45 @@
+import { T_GameState, T_Levels } from "../utils/types";
+import {InputPageWrapper, LevelsWrapper, UnitLevelInput, getInitValueForLevelSelect, getUpgradeOptions } from "./inputGameState";
+
+
+interface I_InputLevelsWorkers {
+    isVisible : boolean,
+    gameState : T_GameState,
+    levels : T_Levels,
+    handleLevelChange : (e : React.ChangeEvent<HTMLSelectElement>) => void, 
+}
+export default function InputLevelsWorkers({isVisible, gameState, levels, handleLevelChange} 
+    : I_InputLevelsWorkers)
+    : JSX.Element {
+
+    const workerUpgrades = [
+        { id: "id_Trinity", labelDisplay: "Trinity", optionsProps: { name: "Trinity", max: 10 }},
+        { id: "id_Bronte", labelDisplay: "Bronte", optionsProps: { name: "Bronte", max: 10 }},
+        { id: "id_Anne", labelDisplay: "Anne", optionsProps: { name: "Anne", max: 8 }},
+        { id: "id_Petra", labelDisplay: "Petra", optionsProps: { name: "Petra", max: 10 }},
+        { id: "id_Manny", labelDisplay: "Manny", optionsProps: { name: "Manny", max: 10 }},
+        { id: "id_Tony", labelDisplay: "Tony", optionsProps: { name: "Tony", max: 10 }},
+        { id: "id_Ruth", labelDisplay: "Ruth", optionsProps: { name: "Ruth", max: 8 }},
+        { id: "id_Rex", labelDisplay: "Rex", optionsProps: { name: "Rex", max: 10 }},
+    ]
+    
+    return <InputPageWrapper isVisible={isVisible} heading={"Worker Levels"} >
+            <LevelsWrapper>
+                
+                { workerUpgrades.map(ele => {
+                    let initValue : string | undefined = getInitValueForLevelSelect(ele.optionsProps.name, gameState);
+                    let keyName = ele.optionsProps.name.toLowerCase();
+                    return <UnitLevelInput key={ele.id} 
+                                keyName={keyName} 
+                                idStr={ele.id} 
+                                labelStr={ele.labelDisplay} 
+                                initValue={initValue}
+                                options={getUpgradeOptions(ele.optionsProps)} 
+                                handleLevelChange={handleLevelChange} 
+                                currentValue={levels[keyName as keyof typeof levels]}
+                            />
+                    })
+                }
+            </LevelsWrapper>
+        </InputPageWrapper>
+}

--- a/app/components/inputGameState_stockpiles.tsx
+++ b/app/components/inputGameState_stockpiles.tsx
@@ -1,0 +1,85 @@
+
+import { resourceCSS } from '../utils/formatting';
+
+
+import { InputPageWrapper, InputNumberAsText } from "./inputGameState";
+
+interface I_InputStockpiles extends Pick<I_StockpileInput, "controlledStockpileValue" | "updateStockpiles"> {
+    isVisible : boolean,
+}
+
+export default function InputStockpiles({isVisible, controlledStockpileValue, updateStockpiles} 
+    : I_InputStockpiles)
+    : JSX.Element {
+
+    return  <InputPageWrapper isVisible={isVisible} heading={"Current Stockpiles"}>
+                <DustInput controlledStockpileValue={controlledStockpileValue} updateStockpiles={updateStockpiles} />
+                <StockpileInput keyId={'blue'} controlledStockpileValue={controlledStockpileValue} updateStockpiles={updateStockpiles} />
+                <StockpileInput keyId={'green'} controlledStockpileValue={controlledStockpileValue} updateStockpiles={updateStockpiles} />
+                <StockpileInput keyId={'red'} controlledStockpileValue={controlledStockpileValue} updateStockpiles={updateStockpiles} />
+                <StockpileInput keyId={'yellow'} controlledStockpileValue={controlledStockpileValue} updateStockpiles={updateStockpiles} />
+            </InputPageWrapper>
+}
+
+interface I_PropsStockpileWrapper { 
+    coloursCSS : string, 
+    idStr : string, 
+    label: string, 
+    children : React.ReactNode 
+}
+function StockpileWrapper({coloursCSS, idStr, label, children} 
+    : I_PropsStockpileWrapper)
+    : JSX.Element {
+
+    return  <div className={"ml-2 flex py-1 px-2 items-center border" + " " + coloursCSS}>
+                <label className={"block w-20"} htmlFor={idStr}>{label}</label>
+                {children}
+            </div>
+}
+
+function extractBorderColourCSS(cssStr : string){
+    const regEx = /border-\w*-\d{2,3}/g;
+    const matchArr = cssStr.match(regEx);
+    if(matchArr === null){
+        return '';
+    }
+    return matchArr[0];
+}
+
+
+interface I_StockpileInput {
+    keyId : string, 
+    controlledStockpileValue : (keyId : string) => string | number, 
+    updateStockpiles : (e : React.ChangeEvent<HTMLInputElement>, keyId : string) => void
+}
+function StockpileInput({keyId, controlledStockpileValue, updateStockpiles} 
+    : I_StockpileInput )
+    : JSX.Element {
+
+    const idStr = `id_${keyId}Stock`;
+    const label = `${keyId.charAt(0).toUpperCase()}${keyId.slice(1)}`;
+    const borderCSS = extractBorderColourCSS(resourceCSS[keyId as keyof typeof resourceCSS].badge);
+    return (
+        <StockpileWrapper coloursCSS={resourceCSS[keyId as keyof typeof resourceCSS].badge} label={label} idStr={idStr}>
+            <InputNumberAsText cssStr={"w-36 text-black py-1 px-2 font-normal" + " " + borderCSS} idStr={idStr} value={controlledStockpileValue(keyId)} handleChange={(e: React.ChangeEvent<HTMLInputElement> ) => updateStockpiles(e, keyId)} />
+        </StockpileWrapper>
+    )
+}
+
+
+function DustInput({controlledStockpileValue, updateStockpiles} 
+    : Pick<I_StockpileInput, "controlledStockpileValue" | "updateStockpiles">)
+    : JSX.Element {
+
+    const borderCSS = extractBorderColourCSS(resourceCSS.dust.badge);
+    return(
+        <StockpileWrapper coloursCSS={resourceCSS.dust.badge} label={"Dust"} idStr={"id_dust"}>
+            <InputNumberAsText 
+                idStr={"id_dust"}
+                cssStr={"w-36 py-1 px-2 font-normal" + " " + borderCSS}
+                value={ controlledStockpileValue('dust') }
+                handleChange={(e) => updateStockpiles(e, 'dust')}
+            />
+        </StockpileWrapper>
+    )
+}

--- a/app/components/stockpilesStrip.tsx
+++ b/app/components/stockpilesStrip.tsx
@@ -29,7 +29,7 @@ function Stockpile({myKey, data}
     : JSX.Element {
 
     return (
-        <div className={"flex justify-between text-sm w-1/4 px-1 gap-1" + " " + resourceCSS[myKey as keyof typeof resourceCSS].badge}>
+        <div className={"flex justify-between text-sm w-1/4 px-1 gap-1 rounded" + " " + resourceCSS[myKey as keyof typeof resourceCSS].badge}>
             <div>{myKey.charAt(0).toUpperCase()}</div>
             <div>{toThousands(data[myKey as keyof typeof data])}</div>
         </div>


### PR DESCRIPTION
Visually broke up game status form into four 'pages' so users don't need to unhide summary/details elements.