### PR TITLE
Refactor modal formatting for all modals

### DIFF
--- a/app/components/badges.tsx
+++ b/app/components/badges.tsx
@@ -10,7 +10,7 @@ export function BadgeCost({data, extraCSS}
     : JSX.Element {
 
     const displayQty = toThousands(parseInt(data.quantity));
-    extraCSS = extraCSS ?? "justify-between px-2 py-0.5 rounded text-xs";
+    extraCSS = extraCSS ?? "justify-between items-center px-2 py-0.5 rounded text-xs";
     
     return (
         <div className={"flex" + " " + extraCSS + " " + resourceCSS[data.egg as keyof typeof resourceCSS].badge}>

--- a/app/components/buttons.tsx
+++ b/app/components/buttons.tsx
@@ -1,4 +1,4 @@
-interface I_Button{
+export interface I_Button{
     size : keyof typeof SIZES,
     colours : keyof typeof COLOURS,
     htmlType? : string,
@@ -9,11 +9,11 @@ interface I_Button{
     children: React.ReactNode,
 }
 
-const COLOURS = {
+export const COLOURS = {
     primary: {
-        main: "text-white bg-violet-700 hover:bg-violet-600",
+        main: "text-white bg-violet-700 hover:bg-violet-600 border-violet-700",
         disabled: "text-gray-500 bg-gray-300",
-        toggledOn: "text-white bg-violet-950 hover:bg-violet-800"
+        toggledOn: "text-white bg-violet-950 hover:bg-violet-800 border-violet-950"
     },
     secondary: {
         main: "border-2 text-violet-600 bg-transparent border-violet-600 hover:bg-violet-50",
@@ -22,6 +22,14 @@ const COLOURS = {
     warning: {
         main: "border-2 text-violet-600 bg-white bg-opacity-50 border-violet-600 hover:bg-red-700 hover:border-red-700 hover:text-white",
         disabled: "border-2 text-gray-500 border-gray-300",
+    },
+    more: {
+        main: "bg-violet-200      border-violet-200   text-white          hover:bg-violet-100     hover:text-violet-400",
+        toggledOn: "bg-violet-300      border-violet-400   text-violet-600     hover:bg-violet-200     hover:text-violet-400",
+    },
+    moreOffline: {
+        main: "bg-greyBlue-400    border-greyBlue-400 text-white          hover:bg-greyBlue-300   hover:text-greyBlue-100",
+        toggledOn: "bg-greyBlue-600    border-greyBlue-800 text-white          hover:bg-greyBlue-300   hover:text-greyBlue-100",
     },
 }
 
@@ -86,5 +94,37 @@ function getValidType(htmlType : string | undefined)
 }
 
 
+interface I_MoreButtonContainer {
+    showMore : boolean,
+    setShowMore : React.Dispatch<React.SetStateAction<boolean>>,
+    modeKey : 'more' | 'moreOffline' | 'primary',
+}
+export function MoreButton({showMore, setShowMore, modeKey,} 
+    : I_MoreButtonContainer)
+    : JSX.Element {
 
+    const onOffKey = showMore ? 'toggledOn' : 'main';
+
+    modeKey = modeKey !== 'moreOffline' && modeKey !== 'primary' ?
+                'more'
+                : modeKey;
+
+    let colourTheme = COLOURS[modeKey as keyof typeof COLOURS];
+    if(!('main' in colourTheme) || !('toggledOn' in colourTheme)){
+        colourTheme = COLOURS.more;
+    }
+    let CSS = colourTheme[onOffKey];
+    
+    return (
+        
+            <button className={"border-2 rounded-full flex align-center justify-center w-7 h-7" + " " + CSS} 
+                    onClick={() => setShowMore(prev => !prev)}
+                    type={'button'}
+                    >
+                <span aria-hidden={true}>...</span>
+                <span className={"sr-only"}>more info</span>
+            </button>
+       
+    )
+}
 

--- a/app/components/inputGameState_general.tsx
+++ b/app/components/inputGameState_general.tsx
@@ -8,37 +8,56 @@ import { capitalise } from '../utils/formatting';
 
 import Select from './select';
 import { Button } from './buttons';
-import { InputPageWrapper, FormRow, Label, formatValueStr, getUpgradeOptions, InputNumberAsText, GAMESTATE_LABEL_CSS_FORMATTING } from "./inputGameState"
+import { formatValueStr, getUpgradeOptions, InputNumberAsText, Label } from "./inputGameState"
 
 
-interface I_InputGeneral extends I_TimeRemainingFieldset, I_Entered {
-    isVisible : boolean,
-    gameState : T_GameState, 
-    handleLevelChange : (e : React.ChangeEvent<HTMLSelectElement>) => void, 
-    hasAdBoost : boolean, 
-    toggleAdBoost : () => void,
-}
-export default function InputGeneral({isVisible, timeRemaining, setTimeRemaining, timeEntered, setStateOnChange, setTimeEntered, gameState, handleLevelChange, hasAdBoost, toggleAdBoost } 
+export interface I_InputGeneral extends I_TimeRemainingFieldset, I_Entered, I_AllEggs, I_AdBoost {}
+export default function InputGeneral({timeRemaining, setTimeRemaining, timeEntered, setStateOnChange, setTimeEntered, gameState, handleLevelChange, hasAdBoost, toggleAdBoost } 
     : I_InputGeneral)
     : JSX.Element {
 
-    return  <InputPageWrapper isVisible={isVisible} heading={"Times and Premium"}>
-        <div>
-                <FormRow extraCSS={"flex gap-2"}>
-                    <TimeRemainingFieldset timeRemaining={timeRemaining} setTimeRemaining={setTimeRemaining} />
-                </FormRow>
-                <FormRow extraCSS={"flex gap-2 items-center"}>
-                    <Entered timeEntered={timeEntered} setStateOnChange={setStateOnChange} setTimeEntered={setTimeEntered}/>
-                </FormRow>
-                <FormRow extraCSS={"flex gap-2"}>
-                    <Select labelExtraCSS={GAMESTATE_LABEL_CSS_FORMATTING} selectExtraCSS={undefined} id={"id_AllEggs"} labelDisplay={"All Eggs"} initValue={gameState === null ? undefined : formatValueStr("All", gameState.premiumInfo.allEggs)} options={getUpgradeOptions({ name: "All", max: 5 })} handleChange={handleLevelChange} />
-                </FormRow>
-                <FormRow extraCSS={"flex gap-2"}>
-                    <Label htmlFor={"id_adBoost"}>Ad Boost</Label>
-                    <input type="checkbox" id="id_adBoost" checked={hasAdBoost} onChange={ toggleAdBoost } />
-                </FormRow>
-                </div>
-            </InputPageWrapper>
+    return  <div className={"flex flex-col gap-6"}>
+                <TimeRemainingFieldset timeRemaining={timeRemaining} setTimeRemaining={setTimeRemaining} />
+                <Entered timeEntered={timeEntered} setStateOnChange={setStateOnChange} setTimeEntered={setTimeEntered} />
+                <AllEggs gameState={gameState} handleLevelChange={handleLevelChange} />
+                <AdBoost hasAdBoost={hasAdBoost} toggleAdBoost={toggleAdBoost} />
+            </div>
+
+}
+
+
+interface I_AllEggs {
+    gameState : T_GameState, 
+    handleLevelChange : (e : React.ChangeEvent<HTMLSelectElement>) => void,
+}
+function AllEggs({gameState, handleLevelChange} 
+    : I_AllEggs) 
+    : JSX.Element {
+
+    return  <div className={"flex gap-2"}>
+                <Label htmlFor={"id_AllEggs"}>All Eggs</Label>
+                <Select 
+                    selectExtraCSS={undefined} 
+                    id={"id_AllEggs"} 
+                    initValue={gameState === null ? undefined : formatValueStr("All", gameState.premiumInfo.allEggs)} 
+                    options={getUpgradeOptions({ name: "All", max: 5 })} handleChange={handleLevelChange} 
+                    />
+            </div>
+}
+
+
+interface I_AdBoost {
+    hasAdBoost : boolean, 
+    toggleAdBoost : () => void,
+}
+function AdBoost({hasAdBoost, toggleAdBoost}
+    : I_AdBoost)
+    : JSX.Element {
+
+    return  <div className={"flex gap-2"}>
+                <Label htmlFor={"id_adBoost"}>Ad Boost</Label>
+                <input type="checkbox" id="id_adBoost" checked={hasAdBoost} onChange={ toggleAdBoost } />
+            </div>
 }
 
 
@@ -54,7 +73,7 @@ function Entered({timeEntered, setStateOnChange, setTimeEntered}
     timeEntered = timeEntered ?? new Date();
 
     return(
-        <>
+        <div className={"flex gap-2 items-center"}>
             <Label htmlFor={"id_timeEntered"}>Entered</Label>
             <p suppressHydrationWarning={true}>{ getDateDisplayStr(timeEntered) }</p>
             <input hidden type="datetime-local" id={"id_timeEntered"} value={timeEntered == null ? "" : `${timeEntered}`} onChange={(e) => setStateOnChange(e, setTimeEntered)}/>
@@ -68,7 +87,7 @@ function Entered({timeEntered, setStateOnChange, setTimeEntered}
             >
                 &laquo;&nbsp;now
             </Button>
-        </>
+        </div>
     )
 }
 
@@ -85,8 +104,8 @@ function TimeRemainingFieldset({timeRemaining, setTimeRemaining}
 
     return (
         <fieldset className={"relative w-full pt-5" + " " + ""}>
-            <legend className={"absolute top-0 mb-2" + " " + GAMESTATE_LABEL_CSS_FORMATTING}>Remaining</legend>
-            <div className={'relative flex flex-col items-center gap-1 px-3 ml-1 mt-2'}>
+            <Label extraCSS={"absolute top-0 font-semibold"} htmlFor={''} tagName={'legend'}>Remaining</Label>
+            <div className={'relative flex flex-col items-center gap-1 px-3 ml-1'}>
                 <div className={'flex justify-center gap-2 mt-1'}>
                     <TimeRemainingUnit unitName={"days"} value={timeRemaining == null ? 0 : timeRemaining.days} handleChange={handleChangeDays} />
                     <TimeRemainingUnit unitName={"hours"} value={timeRemaining == null ? 0 : timeRemaining.hours} handleChange={handleChangeHours} />
@@ -122,6 +141,8 @@ function TimeRemainingUnit({unitName, value, handleChange}
         </div>
     )
 }
+
+
 
 
 type T_OutputUseTimeRemainingFieldset = {

--- a/app/components/inputGameState_levelsOther.tsx
+++ b/app/components/inputGameState_levelsOther.tsx
@@ -1,14 +1,13 @@
 import { T_GameState, T_Levels } from "../utils/types";
-import {InputPageWrapper, FormSubHeading, LevelsWrapper, UnitLevelInput, getInitValueForLevelSelect, getUpgradeOptions } from "./inputGameState";
+import { LevelsWrapper, UnitLevelInput, getInitValueForLevelSelect, getUpgradeOptions } from "./inputGameState";
 
-interface I_InputLevelsOther {
-    isVisible : boolean,
+export interface I_InputLevelsOther {
     gameState : T_GameState,
     levels : T_Levels,
     handleLevelChange : (e : React.ChangeEvent<HTMLSelectElement>) => void, 
 }
 
-export default function InputLevelsOther({isVisible, gameState, levels, handleLevelChange} 
+export default function InputLevelsOther({gameState, levels, handleLevelChange} 
     : I_InputLevelsOther)
     : JSX.Element {
 
@@ -39,13 +38,12 @@ export default function InputLevelsOther({isVisible, gameState, levels, handleLe
     ]
 
 
-    return  <InputPageWrapper isVisible={isVisible} heading={undefined}>
-                <FormSubHeading text={"Egg Levels"} />
-                <LevelsWrapper>
-                    { productionUpgrades.map((ele, idx) => {
+    return  <>
+                <SubSection heading={"Egg Levels"}>
+                    { productionUpgrades.map(ele => {
                             let initValue : string | undefined  = getInitValueForLevelSelect(ele.optionsProps.name, gameState);
                             let keyName = ele.optionsProps.name.toLowerCase();
-                            return <UnitLevelInput key={ele.id} 
+                            return <UnitLevelInput key={`${ele.id}EggLevelField`} 
                                         keyName={keyName} 
                                         idStr={ele.id} 
                                         labelStr={ele.labelDisplay} 
@@ -56,10 +54,9 @@ export default function InputLevelsOther({isVisible, gameState, levels, handleLe
                                     />
                         })
                     }
-                </LevelsWrapper>
+                </SubSection>
 
-                <FormSubHeading text={"Buff Levels"} />
-                <LevelsWrapper>
+                <SubSection heading={"Buff Levels"}>
                     <UnitLevelInput
                         keyName={"speed"} 
                         idStr={"id_speed"} 
@@ -78,8 +75,21 @@ export default function InputLevelsOther({isVisible, gameState, levels, handleLe
                         handleLevelChange={handleLevelChange} 
                         currentValue={levels.dust}
                     />
-                </LevelsWrapper>
-            </InputPageWrapper>
+                </SubSection>
+                
+            </>
 
 }
 
+
+function SubSection({ heading, children }
+    : { heading : string, children : React.ReactNode } )
+    : JSX.Element {
+
+    return  <section className={"first:mt-0 mt-7"}>
+                <h3 className={"font-semibold pb-3"}>{heading}</h3>
+                <LevelsWrapper>
+                    { children }
+                </LevelsWrapper>
+            </section>
+}

--- a/app/components/inputGameState_levelsWorkers.tsx
+++ b/app/components/inputGameState_levelsWorkers.tsx
@@ -1,14 +1,13 @@
 import { T_GameState, T_Levels } from "../utils/types";
-import {InputPageWrapper, LevelsWrapper, UnitLevelInput, getInitValueForLevelSelect, getUpgradeOptions } from "./inputGameState";
+import { LevelsWrapper, UnitLevelInput, getInitValueForLevelSelect, getUpgradeOptions } from "./inputGameState";
 
 
 interface I_InputLevelsWorkers {
-    isVisible : boolean,
     gameState : T_GameState,
     levels : T_Levels,
     handleLevelChange : (e : React.ChangeEvent<HTMLSelectElement>) => void, 
 }
-export default function InputLevelsWorkers({isVisible, gameState, levels, handleLevelChange} 
+export default function InputLevelsWorkers({gameState, levels, handleLevelChange} 
     : I_InputLevelsWorkers)
     : JSX.Element {
 
@@ -23,23 +22,20 @@ export default function InputLevelsWorkers({isVisible, gameState, levels, handle
         { id: "id_Rex", labelDisplay: "Rex", optionsProps: { name: "Rex", max: 10 }},
     ]
     
-    return <InputPageWrapper isVisible={isVisible} heading={"Worker Levels"} >
-            <LevelsWrapper>
-                
-                { workerUpgrades.map(ele => {
-                    let initValue : string | undefined = getInitValueForLevelSelect(ele.optionsProps.name, gameState);
-                    let keyName = ele.optionsProps.name.toLowerCase();
-                    return <UnitLevelInput key={ele.id} 
-                                keyName={keyName} 
-                                idStr={ele.id} 
-                                labelStr={ele.labelDisplay} 
-                                initValue={initValue}
-                                options={getUpgradeOptions(ele.optionsProps)} 
-                                handleLevelChange={handleLevelChange} 
-                                currentValue={levels[keyName as keyof typeof levels]}
-                            />
-                    })
-                }
+    return <LevelsWrapper>
+            { workerUpgrades.map(ele => {
+                let initValue : string | undefined = getInitValueForLevelSelect(ele.optionsProps.name, gameState);
+                let keyName = ele.optionsProps.name.toLowerCase();
+                return <UnitLevelInput key={ele.id} 
+                            keyName={keyName} 
+                            idStr={ele.id} 
+                            labelStr={ele.labelDisplay} 
+                            initValue={initValue}
+                            options={getUpgradeOptions(ele.optionsProps)} 
+                            handleLevelChange={handleLevelChange} 
+                            currentValue={levels[keyName as keyof typeof levels]}
+                        />
+                })
+            }
             </LevelsWrapper>
-        </InputPageWrapper>
 }

--- a/app/components/inputGameState_stockpiles.tsx
+++ b/app/components/inputGameState_stockpiles.tsx
@@ -1,24 +1,22 @@
 
 import { resourceCSS } from '../utils/formatting';
 
+import { InputNumberAsText } from "./inputGameState";
 
-import { InputPageWrapper, InputNumberAsText } from "./inputGameState";
+export interface I_InputStockpiles extends Pick<I_StockpileInput, "controlledStockpileValue" | "updateStockpiles"> {}
 
-interface I_InputStockpiles extends Pick<I_StockpileInput, "controlledStockpileValue" | "updateStockpiles"> {
-    isVisible : boolean,
-}
-
-export default function InputStockpiles({isVisible, controlledStockpileValue, updateStockpiles} 
+export default function InputStockpiles({ controlledStockpileValue, updateStockpiles } 
     : I_InputStockpiles)
     : JSX.Element {
 
-    return  <InputPageWrapper isVisible={isVisible} heading={"Current Stockpiles"}>
+    return  <div className={"flex flex-col gap-3"}>
                 <DustInput controlledStockpileValue={controlledStockpileValue} updateStockpiles={updateStockpiles} />
                 <StockpileInput keyId={'blue'} controlledStockpileValue={controlledStockpileValue} updateStockpiles={updateStockpiles} />
                 <StockpileInput keyId={'green'} controlledStockpileValue={controlledStockpileValue} updateStockpiles={updateStockpiles} />
                 <StockpileInput keyId={'red'} controlledStockpileValue={controlledStockpileValue} updateStockpiles={updateStockpiles} />
                 <StockpileInput keyId={'yellow'} controlledStockpileValue={controlledStockpileValue} updateStockpiles={updateStockpiles} />
-            </InputPageWrapper>
+            </div>
+
 }
 
 interface I_PropsStockpileWrapper { 

--- a/app/components/inputLoad.tsx
+++ b/app/components/inputLoad.tsx
@@ -1,8 +1,10 @@
 import { useId, useState } from 'react';
 
-import Modal, { ModalHeading, ModalSubmitButton, I_Modal } from './modal';
-import Select, { T_OptionData } from './select';
 import { SAVE_FILE_PREFIX } from '../utils/consts';
+
+import Modal, { ModalHeading, ModalSubmitButton, ModalFieldsWrapper, I_Modal } from './modal';
+import { SelectWithLabel, T_OptionData } from './select';
+
 
 interface I_PropsModalLoad extends Pick<I_Modal, "closeModal"> {
     loadInputs : (str : string) => void,
@@ -40,14 +42,28 @@ export default function ModalLoad({closeModal, loadInputs}
     return (
         <Modal closeModal={closeModal}>
             <ModalHeading>
-                Loading
+                Load Plan
             </ModalHeading>
             { options === null ?
-                <p>There is no saved data to load</p>
+                <ModalFieldsWrapper>
+                    <p>There are no saved plans</p>
+                </ModalFieldsWrapper>
                 :
-                <form onSubmit={() => handleSubmit()} className={"flex flex-col gap-1"}>
-                    <Select id={id} selectExtraCSS={"px-2 py-1"} labelDisplay={"Load"} options={options} handleChange={handleChange} initValue={options[0].valueStr} labelExtraCSS={undefined} />
-                    <ModalSubmitButton label={"load"} extraCSS={"mt-5"} disabled={false} />
+                <form onSubmit={() => handleSubmit()}>
+                    <ModalFieldsWrapper>
+                        <div className={"flex flex-col gap-1"}>
+                            <SelectWithLabel 
+                                id={id} 
+                                selectExtraCSS={"px-2 py-1"} 
+                                labelDisplay={"Plan to load"} 
+                                options={options} 
+                                handleChange={handleChange} 
+                                initValue={options[0].valueStr} 
+                                labelExtraCSS={undefined} 
+                            />
+                        </div>
+                    </ModalFieldsWrapper>
+                    <ModalSubmitButton label={"load"} extraCSS={''} disabled={false} />
                 </form>
             }
         </Modal>

--- a/app/components/inputProdSettings.tsx
+++ b/app/components/inputProdSettings.tsx
@@ -7,7 +7,7 @@ import { defaultProductionSettings } from '../utils/defaults';
 import { capitalise, resourceCSS } from '../utils/formatting';
 import { T_Levels, T_ProductionSettings, T_SwitchAction } from '../utils/types';
 
-import Modal, { ModalHeading, ModalSubmitButton, I_Modal } from './modal';
+import Modal, { ModalHeading, ModalSubmitButton, ModalFieldsWrapper, I_Modal } from './modal';
 import Radio from './radio';
 
 
@@ -39,24 +39,23 @@ export default function ModalProdSettings({closeModal, currentProdSettings, curr
 
     return(
         <Modal closeModal={closeModal}>
+            <ModalHeading>Switch Production</ModalHeading>
             <form onSubmit={handleSubmit} className={"flex flex-col w-full"}>
-                <ModalHeading>
-                    Switch Production
-                </ModalHeading>
-
-                <div className={"flex flex-col items-center gap-2 px-3 pb-4 mt-1"}>
-                {
-                    Object.keys(currentProdSettings).map((myKey : string) => {
-                        return <ProductionToggle key={myKey} 
-                                    myKey={myKey} 
-                                    toggledTo={toggles[myKey as keyof typeof toggles]} 
-                                    handleSelection={handleChange} 
-                                    disabled={levels[myKey as keyof typeof levels] === 0}
-                                />
-                    })
-                }
-                </div>
-                <ModalSubmitButton label={"submit"} extraCSS={"mt-2"} disabled={false} />
+                <ModalFieldsWrapper>
+                    <div className={"flex flex-col items-center gap-4 mt-1"}>
+                    {
+                        Object.keys(currentProdSettings).map((myKey : string) => {
+                            return <ProductionToggle key={myKey} 
+                                        myKey={myKey} 
+                                        toggledTo={toggles[myKey as keyof typeof toggles]} 
+                                        handleSelection={handleChange} 
+                                        disabled={levels[myKey as keyof typeof levels] === 0}
+                                    />
+                        })
+                    }
+                    </div>
+                </ModalFieldsWrapper>
+                <ModalSubmitButton label={"submit"} extraCSS={''} disabled={false} />
             </form>
         </Modal>
     )
@@ -97,27 +96,39 @@ function ProductionToggle({myKey, toggledTo, handleSelection, disabled}
         return null;
     }
 
-    let containerCSS = "w-32";
-    let labelCSS = "mb-1";
-    labelCSS += disabled ?
-                " " + "text-gray-300"
-                : "";
-    
+    let labelCSS = disabled ?
+                    " " + "text-gray-300"
+                    : "";
     return (
-        <fieldset className={containerCSS}>
-            <legend className={labelCSS} >
-                { capitalise(myKey) }&nbsp;&raquo;&nbsp;{
+        <fieldset className={"w-32"}>
+            <legend className={"mb-1 flex items-center" + labelCSS} >
+                { capitalise(myKey) }
+                <span aria-hidden={true}>&nbsp;&raquo;&nbsp;</span>
+                <span className={"sr-only"}>currently producing</span>
+                {
                     disabled ?
                     <span>n/a</span>
                     : <CurrentAsCircleBadge type={toggledTo} />
                 }
-                </legend>
+            </legend>
             <div className="flex">
             {
                 data.outputs.map((d, idx) => {
-                    return <Radio key={`${myKey}_${d}`} extraCSS={"w-2/4"} checked={d === toggledTo} disabled={false} handleSelection={() => handleSelection(myKey, d)} value={`${myKey}_${d}`}>
-                        <ToggleDisplay thisOption={d} activeOption={toggledTo} roundLeft={idx === 0} roundRight={idx === numOutputs - 1} disabled={disabled} />
-                    </Radio> 
+                    return  <Radio key={`${myKey}_${d}`} 
+                                extraCSS={"w-2/4"} 
+                                checked={d === toggledTo} 
+                                disabled={false} 
+                                handleSelection={() => handleSelection(myKey, d)} 
+                                value={`${myKey}_${d}`}
+                                >
+                                <ToggleDisplay 
+                                    thisOption={d} 
+                                    activeOption={toggledTo} 
+                                    roundLeft={idx === 0} 
+                                    roundRight={idx === numOutputs - 1} 
+                                    disabled={disabled} 
+                                />
+                            </Radio> 
                 })
             }
             </div>
@@ -131,12 +142,13 @@ function CurrentAsCircleBadge({type}
     : JSX.Element {
 
     let typeCSS = resourceCSS[type as keyof typeof resourceCSS];
+
     return(
         <>
             <div className={"inline-block w-3 h-3 rounded-full" + " " + typeCSS.badge}>             
             </div>
             <span className={"pl-1"}>
-                {type}
+                { type }
             </span>
         </>
     )
@@ -160,17 +172,19 @@ function ToggleDisplay({thisOption, activeOption, roundLeft, roundRight, disable
                             : roundRight ?
                                 "rounded-r-full"
                                 : "";
-    let opacityCSS = thisOption === activeOption && !disabled ?
-                        "" 
-                        : "opacity-20";
+    let opacityCSS = disabled ?
+                        "opacity-10"
+                        : thisOption !== activeOption ?
+                            "opacity-30" 
+                            : "";
     let hoverCSS = disabled ?
                     ""
                     : typeCSS.hover;
     let conditionalCSS = roundingCSS + " " + opacityCSS + " " + hoverCSS;
 
     return(
-        <div className={"flex justify-center content-center py-1 border-2" + " " + typeCSS.badge + " " + conditionalCSS}>
-            {thisOption.charAt(0).toUpperCase()}
+        <div className={"duration-75 ease-linear flex justify-center content-center py-1 border-2" + " " + typeCSS.badge + " " + conditionalCSS}>
+            { thisOption.charAt(0).toLowerCase() }
         </div>
     )
 }

--- a/app/components/inputSave.tsx
+++ b/app/components/inputSave.tsx
@@ -2,7 +2,7 @@ import { useId, useState } from 'react';
 
 import { SAVE_FILE_PREFIX } from '../utils/consts';
 
-import Modal, { ModalHeading, ModalSubmitButton, I_Modal } from './modal';
+import Modal, { ModalHeading, ModalSubmitButton, ModalFieldsWrapper, I_Modal } from './modal';
 import { Button } from './buttons';
 
 
@@ -70,18 +70,24 @@ function SaveForm({name, handleChange, showWarning, handleSubmit}
     return(
         <>
         <ModalHeading>
-            Save
+            Save Plan
         </ModalHeading>
-        <form onSubmit={() => handleSubmit()} className={"flex flex-col gap-1"}>
-            <label htmlFor={id}>Name</label>
-            <input className={"px-2 py-1 border border-neutral-200"} type={"text"} id={id} value={name} onChange={(e) => handleChange(e)}/>
-            {
-                showWarning ?
-                <p>!: There is already a save called &quot;{name}&quot;</p>
-                : null
-            }
-            <ModalSubmitButton label={"save"} extraCSS={undefined} disabled={false} />
+        
+        <form onSubmit={() => handleSubmit()}>
+            <ModalFieldsWrapper>
+                <div className={"flex flex-col gap-1"}>
+                    <label htmlFor={id}>Save as</label>
+                    <input className={"px-2 py-1 border border-neutral-200"} type={"text"} id={id} value={name} onChange={(e) => handleChange(e)}/>
+                    {
+                        showWarning ?
+                        <p>!: There is already a save called &quot;{name}&quot;</p>
+                        : null
+                    }
+                </div>
+            </ModalFieldsWrapper>
+            <ModalSubmitButton label={"save"} extraCSS={''} disabled={false} />
         </form>
+        
         </>
     )
 }
@@ -100,9 +106,12 @@ function OverwriteQuestion({name, goBack, acceptOverwrite}
         <ModalHeading>
             Warning
         </ModalHeading>
-        <div className={"flex flex-col gap-1"}>
-            <p>There is already a save called &quot;{name}&quot;.</p>
-            <div className={"flex justify-between mt-3"}>
+        
+        <div className={"flex flex-col"}>
+            <ModalFieldsWrapper>
+                <p>There is already a save called &quot;{name}&quot;.</p>
+            </ModalFieldsWrapper>
+            <div className={"flex justify-between"}>
                 <Button 
                     size={'twin'}
                     colours={'secondary'}
@@ -119,6 +128,7 @@ function OverwriteQuestion({name, goBack, acceptOverwrite}
                 </Button>
             </div>
         </div>
+        
         </>
     )
 }

--- a/app/components/modal.tsx
+++ b/app/components/modal.tsx
@@ -1,3 +1,5 @@
+import { Dispatch, SetStateAction } from 'react';
+
 import { IconClose } from "./icons";
 import { Button } from './buttons';
 
@@ -12,8 +14,8 @@ export default function Modal({closeModal, children}
     return(
         <div className={"fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50"}>
             <div className={"relative max-h-[calc(100vh-10rem)] overflow-y-auto overflow-x-hidden min-w-[17rem] flex flex-col items-center px-2 py-2 bg-neutral-50 rounded max-w-full m-1"}>
-            <CloseButton close={closeModal} />
-                <div className={"flex flex-col w-full px-3 pb-3"}>
+                <CloseButton close={closeModal} />
+                <div className={"flex flex-col w-[280px] max-w-full px-3 pb-3 text-sm"}>
                     {children}
                 </div>
             </div>
@@ -22,37 +24,11 @@ export default function Modal({closeModal, children}
 }
 
 
-export function ModalHeading({children} 
-    : { children : React.ReactNode })
-    : JSX.Element {
-
-    return  <h2 className={"font-bold text-lg pb-2 mt-3 self-start"}>
-                {children}
-            </h2>
-}
-
-
-export function ModalSubmitButton({label, extraCSS, disabled} 
-    : { label? : string, extraCSS? : string, disabled? : boolean })
-    : JSX.Element {
-
-    let strCSS = extraCSS === undefined ? "mt-5" : extraCSS;
-    return <Button 
-                extraCSS={"justify-self-end w-full" + " " + strCSS} 
-                colours={"primary"}
-                size={"full"}
-                disabled={disabled}
-                >
-                { label ?? "submit" }
-            </Button>
-}
-
-
 interface I_CloseButton {
     close : () => void, 
     extraCSS? : string
 };
-export function CloseButton({close, extraCSS} 
+function CloseButton({close, extraCSS} 
     : I_CloseButton)
     : JSX.Element {
 
@@ -62,4 +38,154 @@ export function CloseButton({close, extraCSS}
                 <span className={'sr-only'}>close</span>
             </button>
 }
+
+
+export function ModalHeading({tagName, children} 
+    : { tagName? : keyof JSX.IntrinsicElements, children : React.ReactNode })
+    : JSX.Element {
+
+    const Tag = tagName !== undefined ?
+                    tagName
+                    :'h2' as keyof JSX.IntrinsicElements;
+
+    return  <Tag className={"font-bold text-lg pl-0.5 mt-2 self-start w-full border-b border-violet-500"}>
+                {children}
+            </Tag>
+}
+
+
+export function ModalSubHeading({tagName, children} 
+    : { tagName? : keyof JSX.IntrinsicElements, children : React.ReactNode })
+    : JSX.Element {
+
+    const Tag = tagName !== undefined ?
+                tagName
+                :'h3' as keyof JSX.IntrinsicElements;
+
+    return  <Tag className={"pl-0.5 text-md font-medium text-black"}>
+                {children}
+            </Tag>
+}
+
+
+export function ModalFieldsWrapper({children}
+    : { children : React.ReactNode })
+    : JSX.Element {
+
+    return  <div className={"pt-6 pb-10"}>
+                {children}
+            </div>
+}
+
+
+export function ModalSubmitButton({label, extraCSS, disabled} 
+    : { label? : string, extraCSS? : string, disabled? : boolean })
+    : JSX.Element {
+
+    return <Button 
+                extraCSS={"justify-self-end w-full" + " " + extraCSS} 
+                colours={"primary"}
+                size={"full"}
+                disabled={disabled}
+                >
+                { label ?? "submit" }
+            </Button>
+}
+
+
+interface I_ModalMultiPageNav {
+    activePage : number, 
+    numPages : number, 
+    changePage : Dispatch<SetStateAction<number>>
+}
+export function ModalMultiPageNav({activePage, numPages, changePage}
+    : I_ModalMultiPageNav)
+    : JSX.Element {
+
+    return  <div aria-hidden={true} className={"flex flex-col justify-center gap-5"}>
+                <NavButtonBox activePage={activePage} numPages={numPages} changePage={changePage} />
+                <ProgressStatus activePage={activePage} numPages={numPages} changePage={changePage} />
+            </div>
+
+}
+
+
+function NavButtonBox({activePage, numPages, changePage}
+    : I_ModalMultiPageNav)
+    : JSX.Element {
+
+    const isLastPage = activePage === numPages
+
+    return  <div className={"flex justify-center"}>
+                <div className={"flex justify-between w-full"}>
+                    <Button
+                        colours={'secondary'}
+                        htmlType={'button'}
+                        size={'twin'}
+                        onClick={() => activePage === 1 ? undefined : changePage(activePage - 1)}
+                        disabled={activePage === 1}
+                    >
+                        &laquo;&nbsp;previous
+                    </Button>
+                    {
+                        isLastPage ?
+                            <Button
+                                key={'submitBtn'}
+                                colours={'primary'}
+                                htmlType={'submit'}
+                                size={'twin'}
+                                onClick={undefined}
+                                disabled={false}
+                            >
+                                submit
+                            </Button>
+                        :
+                            <Button
+                                key={'nextBtn'}
+                                colours={'primary'}
+                                htmlType={'button'}
+                                size={'twin'}
+                                onClick={() => changePage(activePage + 1)}
+                                disabled={isLastPage}
+                            >
+                                next&nbsp;&raquo;
+                            </Button>
+                    }
+                </div>
+            </div>
+}
+
+
+function ProgressStatus({activePage, numPages, changePage}
+    : I_ModalMultiPageNav)
+    : JSX.Element {
+
+    const range = (start : number, stop : number, step : number) =>
+        Array.from({ length: (stop - start) / step + 1 }, (_, i) => start + i * step);
+
+    return  <div aria-hidden={true} className={"w-full flex gap-4 justify-center"}>
+                {
+                    range(1, numPages, 1).map(ele => {
+                        return <CircleButton key={`formProgBtn${ele}`} 
+                                    isActive={activePage === ele} 
+                                    handleClick={ () => changePage(ele) } 
+                                />
+                    })
+                }
+            </div>
+}
+
+
+function CircleButton({isActive, handleClick}
+    : { isActive : boolean, handleClick : () => void })
+    : JSX.Element {
+
+    const selectionCSS = isActive ? 
+            "bg-violet-500"
+            :
+            "bg-neutral-300 hover:bg-neutral-400";
+    return <button type={'button'} className={"rounded-full w-3 h-3" + " " + selectionCSS} onClick={handleClick}></button>
+}
+
+
 

--- a/app/components/planner_timeGroup.tsx
+++ b/app/components/planner_timeGroup.tsx
@@ -1,14 +1,13 @@
 import { useState } from 'react';
 
 import { T_OfflinePeriod, T_TimeGroup,  T_GameState} from '../utils/types';
-import { calcDHMString, convertOfflineTimeToTimeId, convertTimeIdToTimeRemaining, convertTimeIdToDate, getDateDisplayStr, getStartTime } from '../utils/dateAndTimeHelpers';
-import { MAX_TIME } from '../utils/consts';
+import { convertOfflineTimeToTimeId, getStartTime } from '../utils/dateAndTimeHelpers';
 
 import UpgradeCard from './planner_upgradeCard';
 import TimeGroupMore from './planner_timeGroupMore';
 import TimeGroupHeading from './planner_timeGroupHeading';
+import { MoreButton } from './buttons';
 
-import { IconMoon } from './icons';
 
 interface I_TimeGroup {
     gameState : T_GameState, 
@@ -53,11 +52,13 @@ export default function TimeGroup({groupData, startPos, openUpgradePicker, offli
                         isDuringOfflinePeriod={isDuringOfflinePeriod}
                         openUpgradePicker={openUpgradePicker}
                     />
-                    <MoreButtonContainer 
-                        showMore={showMore}
-                        setShowMore={setShowMore}
-                        isDuringOfflinePeriod={isDuringOfflinePeriod}
-                    />
+                    <div className={"self-end pb-2 pl-1"}>
+                        <MoreButton 
+                            showMore={showMore}
+                            setShowMore={setShowMore}
+                            modeKey={isDuringOfflinePeriod ? 'moreOffline' : 'more'}
+                        />
+                    </div>
                 </div>
             </div>
             { showMore ?
@@ -81,8 +82,7 @@ export default function TimeGroup({groupData, startPos, openUpgradePicker, offli
 interface I_UpdateCardContainer extends Pick<T_TimeGroup, "upgrades">, 
                                         Pick<I_TimeGroup, "openUpgradePicker" | "startPos"> {
         isDuringOfflinePeriod : boolean,
-    }
-
+}
 function UpdateCardContainer({upgrades, startPos, isDuringOfflinePeriod, openUpgradePicker} 
     : I_UpdateCardContainer)
     : JSX.Element {
@@ -102,45 +102,5 @@ function UpdateCardContainer({upgrades, startPos, isDuringOfflinePeriod, openUpg
         </div>
     )
 }
-
-
-
-
-interface I_MoreButtonContainer {
-    showMore : boolean,
-    setShowMore : React.Dispatch<React.SetStateAction<boolean>>,
-    isDuringOfflinePeriod : boolean,
-}
-function MoreButtonContainer({showMore, setShowMore, isDuringOfflinePeriod,} 
-    : I_MoreButtonContainer)
-    : JSX.Element {
-
-    const COLOURS = {
-        normal: {
-            on:     "bg-violet-300      border-violet-400   text-violet-600     hover:bg-violet-200     hover:text-violet-400",
-            off:    "bg-violet-200      border-violet-200   text-white          hover:bg-violet-100     hover:text-violet-400",
-        },
-        offlineMode: {
-            on:     "bg-greyBlue-600    border-greyBlue-800 text-white          hover:bg-greyBlue-300   hover:text-greyBlue-100",
-            off:    "bg-greyBlue-400    border-greyBlue-400 text-white          hover:bg-greyBlue-300   hover:text-greyBlue-100",
-        }
-    }
-
-    const modeKey = isDuringOfflinePeriod ? 'offlineMode' : 'normal';
-    const onOffKey = showMore ? 'on' : 'off';
-    const toggleMoreCSS = COLOURS[modeKey][onOffKey];
-
-    return (
-        <div className={"self-end pb-2 pl-1"}>
-            <button className={"border-2 rounded-full flex align-center justify-center w-7 h-7" + " " + toggleMoreCSS} 
-                    onClick={() => setShowMore(prev => !prev)}
-                    >
-                <span aria-hidden={true}>...</span>
-                <span className={"sr-only"}>more info</span>
-            </button>
-        </div>
-    )
-}
-
 
 

--- a/app/components/radio.tsx
+++ b/app/components/radio.tsx
@@ -14,7 +14,15 @@ export default function Radio({checked, extraCSS, disabled, handleSelection, val
     disabled = disabled ?? false;
     
     return  <label className={extraCSS}>
-                <input type={"radio"} className={"sr-only"} value={value} checked={checked} disabled={disabled} onChange={() => handleSelection()} onClick={() => handleSelection()} />
+                <input 
+                    type={"radio"} 
+                    className={"sr-only"} 
+                    value={value} 
+                    checked={checked} 
+                    disabled={disabled} 
+                    onChange={() => handleSelection()} 
+                    onClick={() => handleSelection()} 
+                />
                 {children}
             </label>
 }

--- a/app/components/sectionGameState.tsx
+++ b/app/components/sectionGameState.tsx
@@ -2,11 +2,9 @@
 
 import UPGRADE_DATA from '../upgrades.json';
 
-
 import { getDateDisplayStr, convertTimeIdToTimeRemaining } from '../utils/dateAndTimeHelpers';
 import { maxedLevelCSS, capitalise, resourceCSS, toBillions, nbsp } from '../utils/formatting';
 import { T_GameState, T_Levels, T_Stockpiles } from '../utils/types';
-
 
 import StockpilesDisplay from './stockpilesStrip';
 import { InputResultsSection, EditButtonBox } from './sectionInputResults';
@@ -70,6 +68,7 @@ function TimeAndPremiumStatus({gameState}
 
 }
 
+
 function GridRowWrapper({title, children} : { title : string, children : React.ReactNode }){
     return  <>
                 <div className={"col-start-1"}>{title}</div>
@@ -88,7 +87,7 @@ function StockpilesStatus({stockpiles}
                     <div>{stockpiles.dust.toLocaleString()}</div>
                     <div className={"justify-self-end"}>({toBillions(stockpiles.dust)})</div>
                 </div>
-                <StockpilesDisplay stockpiles={stockpiles} extraCSS={"gap-1"} wantDust={false} />
+                <StockpilesDisplay stockpiles={stockpiles} extraCSS={"gap-1"} />
             </Subsection>
 }
 
@@ -130,13 +129,13 @@ function LevelsStatus({levels}
     )
 }
 
+
 interface T_LevelWithLabel{
     label : string,
     level : number,
     max : number,
     gridPosCSS? : string
 }
-
 function LevelWithLabel({label, level, max, gridPosCSS} 
     : T_LevelWithLabel)
     : JSX.Element {

--- a/app/components/select.tsx
+++ b/app/components/select.tsx
@@ -1,30 +1,75 @@
 interface I_SelectProps {
     id : string,
-    labelDisplay : string,
     options : T_OptionData[],
     handleChange : (e: React.ChangeEvent<HTMLSelectElement>) => void,
     initValue : string | null | undefined,
-    labelExtraCSS? : string,
     selectExtraCSS? : string
 }
 
-export default function Select({id, labelExtraCSS, selectExtraCSS, labelDisplay, options, handleChange, initValue} : I_SelectProps){
+export default function Select({id, selectExtraCSS, options, handleChange, initValue} 
+    : I_SelectProps)
+    : JSX.Element {
+
     initValue = initValue === null ? undefined : initValue;
 
-    return (
-        <>
-            <label className={labelExtraCSS} htmlFor={id}>{labelDisplay}</label>
-            <select id={id} onChange={(e) => handleChange(e)} defaultValue={initValue} className={"border border-neutral-200"+ " " + selectExtraCSS}>
+    return  <select id={id} onChange={(e) => handleChange(e)} defaultValue={initValue} className={"border border-neutral-300 rounded-sm"+ " " + selectExtraCSS}>
             {
                 options.map( (ele, idx) => {
                     return <Option key={idx} valueStr={ele.valueStr} displayStr={ele.displayStr} />
                 })
             }
             </select>
+}
+
+interface I_SelectWithLabelProps extends I_SelectProps {
+    labelDisplay : string,
+    labelExtraCSS? : string,
+}
+
+export function SelectWithLabel({id, labelExtraCSS, selectExtraCSS, labelDisplay, options, handleChange, initValue} 
+    : I_SelectWithLabelProps)
+    : JSX.Element {
+
+    initValue = initValue === null ? undefined : initValue;
+
+    return (
+        <>
+            <label className={labelExtraCSS} htmlFor={id}>{labelDisplay}</label>
+            <Select id={id} selectExtraCSS={selectExtraCSS} options={options} handleChange={handleChange} initValue={initValue} />
         </>
     )
 
 }
+
+
+// interface I_SelectProps {
+//     id : string,
+//     labelDisplay : string,
+//     options : T_OptionData[],
+//     handleChange : (e: React.ChangeEvent<HTMLSelectElement>) => void,
+//     initValue : string | null | undefined,
+//     labelExtraCSS? : string,
+//     selectExtraCSS? : string
+// }
+
+// export default function Select({id, labelExtraCSS, selectExtraCSS, labelDisplay, options, handleChange, initValue} : I_SelectProps){
+//     initValue = initValue === null ? undefined : initValue;
+
+//     return (
+//         <>
+//             <label className={labelExtraCSS} htmlFor={id}>{labelDisplay}</label>
+//             <select id={id} onChange={(e) => handleChange(e)} defaultValue={initValue} className={"border border-neutral-300"+ " " + selectExtraCSS}>
+//             {
+//                 options.map( (ele, idx) => {
+//                     return <Option key={idx} valueStr={ele.valueStr} displayStr={ele.displayStr} />
+//                 })
+//             }
+//             </select>
+//         </>
+//     )
+
+// }
+
 
 export type T_OptionData = {
     valueStr : string,

--- a/app/components/stockpilesStrip.tsx
+++ b/app/components/stockpilesStrip.tsx
@@ -1,18 +1,15 @@
 import { toThousands, resourceCSS } from "../utils/formatting"
 import { T_Stockpiles } from "../utils/types";
 
+
 interface I_StockpilesDisplay {
     stockpiles : T_Stockpiles,
     extraCSS? : string,
     wantDust? : boolean
 }
-export default function StockpilesDisplay({stockpiles, extraCSS, wantDust} 
+export default function StockpilesDisplay({stockpiles, extraCSS} 
     : I_StockpilesDisplay)
     : JSX.Element {
-
-    if(wantDust === undefined){
-        wantDust === true;
-    }
 
     return (
         <div className={"flex" + " " + extraCSS}>
@@ -24,13 +21,14 @@ export default function StockpilesDisplay({stockpiles, extraCSS, wantDust}
     )
 }
 
+
 function Stockpile({myKey, data} 
     : { myKey : string, data: T_Stockpiles })
     : JSX.Element {
 
     return (
         <div className={"flex justify-between text-sm w-1/4 px-1 gap-1 rounded" + " " + resourceCSS[myKey as keyof typeof resourceCSS].badge}>
-            <div>{myKey.charAt(0).toUpperCase()}</div>
+            <div>{myKey.charAt(0).toLowerCase()}</div>
             <div>{toThousands(data[myKey as keyof typeof data])}</div>
         </div>
     )


### PR DESCRIPTION
> Heading has an underline
> Subheadings are supported
> Added a wrapper to handle top and bottom spacing around modal content
> 'previous' and 'next' buttons added to GameState
> Improved consistency of how egg colours are displayed
> Adjusted opacity for disabled / not selected
> Added a little animation
> Upgrade picker now looks more radio-y (added circles for selection,
  instead of a "left border")
> Stockpile info on upgrade picker is now hidden behind a "more" button