### PR TITLE
Adjust top banner content; add Tooltip

### DIFF
--- a/app/components/select.tsx
+++ b/app/components/select.tsx
@@ -42,35 +42,6 @@ export function SelectWithLabel({id, labelExtraCSS, selectExtraCSS, labelDisplay
 }
 
 
-// interface I_SelectProps {
-//     id : string,
-//     labelDisplay : string,
-//     options : T_OptionData[],
-//     handleChange : (e: React.ChangeEvent<HTMLSelectElement>) => void,
-//     initValue : string | null | undefined,
-//     labelExtraCSS? : string,
-//     selectExtraCSS? : string
-// }
-
-// export default function Select({id, labelExtraCSS, selectExtraCSS, labelDisplay, options, handleChange, initValue} : I_SelectProps){
-//     initValue = initValue === null ? undefined : initValue;
-
-//     return (
-//         <>
-//             <label className={labelExtraCSS} htmlFor={id}>{labelDisplay}</label>
-//             <select id={id} onChange={(e) => handleChange(e)} defaultValue={initValue} className={"border border-neutral-300"+ " " + selectExtraCSS}>
-//             {
-//                 options.map( (ele, idx) => {
-//                     return <Option key={idx} valueStr={ele.valueStr} displayStr={ele.displayStr} />
-//                 })
-//             }
-//             </select>
-//         </>
-//     )
-
-// }
-
-
 export type T_OptionData = {
     valueStr : string,
     displayStr : string   

--- a/app/components/tooltip.tsx
+++ b/app/components/tooltip.tsx
@@ -1,0 +1,14 @@
+import { ReactNode } from 'react';
+
+export default function Tooltip({close, posAndWidthCSS, children} : { close : () => void, posAndWidthCSS? : string, children : ReactNode }){
+
+    posAndWidthCSS = posAndWidthCSS ?? "top-0.5 right-8 z-30 w-11/12";
+
+    return  <button 
+                className={'absolute border-2 border-violet-50 bg-violet-950 text-violet-50 shadow-lg rounded-md [max-width:90vw] py-2 px-3' + ' ' + posAndWidthCSS}
+                onClick={close}
+                type={'button'}
+                >
+                { children }
+            </button>
+}

--- a/app/utils/productionSettings.tsx
+++ b/app/utils/productionSettings.tsx
@@ -3,7 +3,10 @@ import { defaultProductionSettings } from './defaults';
 import { T_Action, T_ProductionSettings, T_TimeGroup } from './types';
 
 
-export function getProductionSettings({actions, index} : {actions : T_Action[], index : number}){
+export function getProductionSettings({actions, index} 
+    : {actions : T_Action[], index : number})
+    : T_ProductionSettings {
+
     let prodSwitchesOnly = actions.slice(0, index).filter((ele) => ele.type === 'switch');
     let result = deepCopy(defaultProductionSettings);
 


### PR DESCRIPTION
Reworded top banner to emphasise that win/lose is about 1st prize. Reworded top banner to describe the second number as "rec." rather than "best", which is a bit less misleading.
Added a tooltip and a ? button to abbreviate to fit on mobile and look more consistent with the "now" number.