### PR TITLE
Refactor Planner; move insert to left

### DIFF
--- a/app/components/planner.tsx
+++ b/app/components/planner.tsx
@@ -1,18 +1,17 @@
-import {useState, Fragment} from 'react';
+import { MAX_TIME } from '../utils/consts';
+import { T_OfflinePeriod, T_ProductionSettings, T_PurchaseData, T_TimeGroup, T_Action, T_GameState, T_ProductionSettingsNow } from '../utils/types';
 
-import { MAX_TIME, deepCopy } from '../utils/consts';
-import { convertDateToTimeId, convertOfflineTimeToTimeId, getStartTime } from '../utils/dateAndTimeHelpers';
-import { moveIsValid, T_ValidMoveOutput } from '../utils/editPlan';
-import { removeAllSwitchActionsInTimeGroup, countInternalProductionSwitches, getNewSwitchActions } from '../utils/productionSettings';
-import { T_OfflinePeriod, T_ProductionSettings, T_PurchaseData, T_TimeGroup, T_Action, T_GameState, T_Levels, T_InterruptProductionSettings } from '../utils/types';
+import { useSwitchProductionNow, T_PropsSwitchProdNowModal } from '../utils/useSwitchProductionNow';
+import { useSwitchProductionFuture, T_PropsSwitchProdFutureModal } from '../utils/useSwitchProductionFuture';
+import { useUpgradePicker, T_PropsUpgradePickerModal } from '../utils/useUpgradePicker';
 
 import ProductionSwitcher from './inputProdSettings';
 import UpgradePicker from './inputUpgradePicker';
 import ControlsRow from './planner_controlsRow';
 import TimeGroup from './planner_timeGroup';
-import ProductionSummary from './productionSummary';
 import PlannerFooter from './planner_footer';
 import ResultAtTop from './resultAtTop';
+
 
 
 interface I_Planner {
@@ -22,167 +21,65 @@ interface I_Planner {
     offlinePeriods : T_OfflinePeriod[],
     purchaseData : T_PurchaseData[],
     timeIdGroups : T_TimeGroup[],
-    prodSettingsAtTop : T_InterruptProductionSettings | null,
-    setProdSettingsAtTop : React.Dispatch<React.SetStateAction<T_InterruptProductionSettings | null>>
+    prodSettingsNow : T_ProductionSettingsNow | null,
+    setProdSettingsNow : React.Dispatch<React.SetStateAction<T_ProductionSettingsNow | null>>
 }
 
-export default function Planner({timeIdGroups, gameState, actions, setActions, offlinePeriods, purchaseData, prodSettingsAtTop, setProdSettingsAtTop} 
+export default function Planner({timeIdGroups, gameState, actions, setActions, offlinePeriods, purchaseData, prodSettingsNow: prodSettingsNow, setProdSettingsNow: setProdSettingsNow} 
     : I_Planner)
     : JSX.Element {
 
-    const [showUpgradePicker, setShowUpgradePicker] = useState(false);
-    const [pickerTargetIdx, setPickerTargetIdx] = useState<number | null>(null);
-    const [showProdSetter, setShowProdSetter] = useState(false);
-    const [modalProdSwitchData, setModalProdSwitchData] = useState<T_TimeGroup | null>(null);
-    const [showProdSetterTop, setShowProdSetterTop] = useState(false);
-    
     const numValid : number = purchaseData.filter(ele => ele.timeId < MAX_TIME).length;
 
-    function movePlanElement({oldIdx, newIdx} 
-        : { oldIdx : number, newIdx : number }) 
-        : void {
-       
-        let validMoveCheck : T_ValidMoveOutput = moveIsValid({srcIdx: oldIdx, dstIdx: newIdx, purchaseData});
-
-        let actionsOldIdx = purchaseData[oldIdx].actionsIdx;
-        let actionsNewIdx = purchaseData[newIdx].actionsIdx;
-
-        if(validMoveCheck.isValid){
-            let upgradeOrderDeepCopy = deepCopy(actions);
-            let targetElement = upgradeOrderDeepCopy[actionsOldIdx];
-
-            upgradeOrderDeepCopy.splice(actionsOldIdx, 1);
-            upgradeOrderDeepCopy.splice(actionsNewIdx, 0, targetElement);
-
-            setActions(upgradeOrderDeepCopy);
-        }
-        else {
-            console.log(`TODO: response to invalid move (${validMoveCheck.reason})`);
-        }
-    }
-
-    function updateProductionSettings(newSettings : T_ProductionSettings)
-        : void {
-
-        if(modalProdSwitchData === null){
-            return;
-        }
-
-        let workingActions : T_Action[] = deepCopy(actions);
-        let numInternalSwitches = 0;
-
-        if(modalProdSwitchData.switches.length > 0){
-            workingActions = removeAllSwitchActionsInTimeGroup({ timeGroupData: modalProdSwitchData, workingActions });
-            numInternalSwitches = countInternalProductionSwitches({ timeGroupData: modalProdSwitchData });
-        }
-
-        let lastUpgrade = modalProdSwitchData.upgrades[modalProdSwitchData.upgrades.length - 1];
-        let insertIdx = lastUpgrade.actionsIdx + 1 - numInternalSwitches;
-
-        let newSwitchActions = getNewSwitchActions({
-            startSettings: modalProdSwitchData.productionSettings,
-            newSettings,
-            insertIdx
-        });
-
-        workingActions = workingActions.slice(0, insertIdx).concat(newSwitchActions).concat(workingActions.slice(insertIdx));  
-        setActions(workingActions);
-    }
-
-
-    function openUpgradePicker(idx : number)
-        : void {
-
-        setPickerTargetIdx(idx);
-        setShowUpgradePicker(true);
-    }
-
-    function openProdSettingsModal(data : T_TimeGroup)
-        : void {
-
-        setModalProdSwitchData(data);
-        setShowProdSetter(true);
-    }
-
-    function updateInterrupt(newSettings : T_ProductionSettings) 
-        : void {
-
-        setProdSettingsAtTop({
-            productionSettings: newSettings,
-            timeId: convertDateToTimeId(new Date(), gameState)
-        })
-    }
-
-    let initialProdSettings : T_ProductionSettings = prodSettingsAtTop === null ?
+    let initialProdSettings : T_ProductionSettings = prodSettingsNow === null ?
                                 timeIdGroups[0].productionSettings
-                                : prodSettingsAtTop.productionSettings;
+                                : prodSettingsNow.productionSettings;
 
-
-    let upgradePickerProps : T_PropsUpgradePickerModal = {
-        showModal: showUpgradePicker,
-        closeModal: () => setShowUpgradePicker(false),
-        movePlanElement: movePlanElement,
-        pickerTargetIdx: pickerTargetIdx
-    }
-
-    let middleProdSwitcherProps : T_PropsMiddleProdSwitcherModal = {
-        showModal: showProdSetter,
-        closeModal: () => setShowProdSetter(false),
-        data: modalProdSwitchData,
-        updateProdSettings: updateProductionSettings
-    }
-
-    let topProdSwitcherProps : T_PropsTopProdSwitcherModal = {
-        showModal: showProdSetterTop,
-        closeModal: () => setShowProdSetterTop(false),
-        initialProdSettings,
-        updateProdSettings: updateInterrupt,
-        levelsAtStart: timeIdGroups[0].levels
-    }
-
+    const { openModal: openUpgradePicker, props: upgradePickerProps } = useUpgradePicker({purchaseData, actions, setActions});
+    const { openModal: openSwitchFutureModal, props: switchProdFutureProps } = useSwitchProductionFuture({ actions, setActions });
+    const { openModal: openSwitchNowModal, props: switchProdNowProps } = useSwitchProductionNow({ initialProdSettings, setProdSettingsNow, gameState, timeIdGroups });
+    
     return(
         <div className={"flex flex-col items-center bg-white"}>
-            
-            <ResultAtTop planData={purchaseData} gameState={gameState} actions={actions} timeIdGroups={timeIdGroups} />
-            {
-                <Modal 
-                    purchaseData={purchaseData} 
-                    gameState={gameState} 
-                    upgradePickerProps={upgradePickerProps}
-                    middleProdSwitcherProps={middleProdSwitcherProps}
-                    topProdSwitcherProps={topProdSwitcherProps}
-                />
-            }
+            <ResultAtTop 
+                planData={purchaseData} 
+                gameState={gameState} 
+                actions={actions} 
+                timeIdGroups={timeIdGroups} 
+            />
+            <Modals 
+                purchaseData={purchaseData} 
+                gameState={gameState} 
+                upgradePickerProps={upgradePickerProps}
+                switchProdFutureProps={switchProdFutureProps}
+                switchProdNowProps={switchProdNowProps}
+            />
 
-            { timeIdGroups.length > 0 && gameState.levels.trinity > 0 ?
-                <ProductionStrip
-                    currentProdSettings={initialProdSettings} 
-                    gameState={gameState} 
-                />
-                : null
-            }
-            
             <div className={"flex flex-col gap-1 w-min"}>
             {
                 timeIdGroups.length === 0 ?
                     null
                     : 
                     <>
-                        <ControlsRow 
-                            displaySwitches={timeIdGroups[0].switches.filter(ele => {
-                                let data = timeIdGroups[0];
-                                return data.productionSettings[ele.key as keyof typeof data.productionSettings] !== ele.to;
-                            })}
-                            handleProductionClick={() => setShowProdSetterTop(true)} 
-                            handleUpgradeClick={() => openUpgradePicker(0)}
-                            showUpgradeButton={true}
-                        />
+                        { gameState.levels.trinity > 0 ?
+                            <ControlsRow 
+                                displaySwitches={timeIdGroups[0].switches.filter(ele => {
+                                    let data = timeIdGroups[0];
+                                    return data.productionSettings[ele.key as keyof typeof data.productionSettings] !== ele.to;
+                                })}
+                                handleProductionClick={openSwitchNowModal} 
+                                handleUpgradeClick={() => openUpgradePicker(0)}
+                                showUpgradeButton={true}
+                            />
+                            : null
+                        }
+
                         <TimeGroupsList
                             gameState={gameState}
                             offlinePeriods={offlinePeriods}
                             timeIdGroups={timeIdGroups}
                             openUpgradePicker={openUpgradePicker}
-                            openProdSwitcherModal={openProdSettingsModal}
+                            openProdSwitcherModal={openSwitchFutureModal}
                             purchasesPassTimeLimit={numValid < purchaseData.length}
                         />
                     </>
@@ -198,39 +95,15 @@ export default function Planner({timeIdGroups, gameState, actions, setActions, o
     )
 }
 
-type T_PropsUpgradePickerModal = {
-    showModal : boolean,
-    closeModal : () => void,
-    movePlanElement : (data : { oldIdx : number, newIdx : number }) => void,
-    pickerTargetIdx : number | null,
-}
 
-type T_PropsMiddleProdSwitcherModal = {
-    showModal : boolean,
-    closeModal : () => void,
-    data : T_TimeGroup | null,
-    updateProdSettings : (newSettings : T_ProductionSettings) => void,
-}
-
-type T_PropsTopProdSwitcherModal = {
-    showModal : boolean,
-    closeModal : () => void,
-    initialProdSettings : T_ProductionSettings,
-    updateProdSettings : (newSettings : T_ProductionSettings) => void,
-    levelsAtStart : T_Levels
-}
-
-interface I_PlannerModals extends 
-    Pick<I_Planner, "gameState" | "purchaseData">{
+interface I_PlannerModals extends Pick<I_Planner, "gameState" | "purchaseData"> {
     upgradePickerProps : T_PropsUpgradePickerModal,
-    middleProdSwitcherProps : T_PropsMiddleProdSwitcherModal,
-    topProdSwitcherProps : T_PropsTopProdSwitcherModal,
+    switchProdFutureProps : T_PropsSwitchProdFutureModal,
+    switchProdNowProps : T_PropsSwitchProdNowModal,
 }
-
-function Modal({ purchaseData, gameState, upgradePickerProps, middleProdSwitcherProps: middleSwitcher, topProdSwitcherProps: topSwitcher } 
+function Modals({ purchaseData, gameState, upgradePickerProps, switchProdFutureProps: switchFuture, switchProdNowProps: switchNow } 
     : I_PlannerModals) 
     : JSX.Element | null{
-
 
     return upgradePickerProps.showModal ?
             <UpgradePicker 
@@ -240,47 +113,23 @@ function Modal({ purchaseData, gameState, upgradePickerProps, middleProdSwitcher
                 purchaseData={ purchaseData } 
                 gameState={ gameState } 
              />
-            : middleSwitcher.showModal && middleSwitcher.data !== null ?
+            : switchFuture.isVisible && switchFuture.data !== null ?
                 <ProductionSwitcher 
-                    closeModal={ middleSwitcher.closeModal } 
-                    currentProdSettings={ middleSwitcher.data.productionSettings } 
-                    currentSwitches={ middleSwitcher.data.switches } 
-                    updateProdSettings={ middleSwitcher.updateProdSettings }
-                    levels={ middleSwitcher.data.levels }
+                    closeModal={ switchFuture.closeModal } 
+                    currentProdSettings={ switchFuture.data.productionSettings } 
+                    currentSwitches={ switchFuture.data.switches } 
+                    updateProdSettings={ switchFuture.updateProdSettings }
+                    levels={ switchFuture.data.levels }
                 />
-                : topSwitcher.showModal ?
+                : switchNow.isVisible ?
                     <ProductionSwitcher 
-                        closeModal={ topSwitcher.closeModal } 
-                        currentProdSettings={ topSwitcher.initialProdSettings } 
+                        closeModal={ switchNow.closeModal } 
+                        currentProdSettings={ switchNow.initialProdSettings } 
                         currentSwitches={ [] } 
-                        updateProdSettings={ topSwitcher.updateProdSettings }
-                        levels={ topSwitcher.levelsAtStart }
+                        updateProdSettings={ switchNow.updateProdSettings }
+                        levels={ switchNow.levelsAtStart }
                     />
                     : null;
-}
-
-
-function ProductionStrip({currentProdSettings, gameState} 
-    : Pick<I_Planner, "gameState"> & {currentProdSettings : T_ProductionSettings})
-    : JSX.Element {
-
-    return(
-        <div className={"flex px-2 py-2 justify-center items-center"}>
-            <div className={"flex gap-2 relative"}>
-            <h4 className={"text-xs absolute -left-9 top-0.5"}>Prod.</h4>
-            { currentProdSettings !== null ?
-                <ProductionSummary 
-                    productionSettings={currentProdSettings} 
-                    levels={gameState.levels} 
-                    extraCSS={undefined}
-                    wantHeadings={false}
-                    isDuringOfflinePeriod={false}
-                />
-                : null
-            }
-            </div>
-        </div>
-    )
 }
 
 
@@ -290,57 +139,42 @@ interface I_TimeGroupList extends
     openProdSwitcherModal: (data : T_TimeGroup) => void,
     purchasesPassTimeLimit : boolean
 }
-function TimeGroupsList({timeIdGroups, offlinePeriods, gameState, openUpgradePicker, openProdSwitcherModal, purchasesPassTimeLimit} : I_TimeGroupList)
+function TimeGroupsList({timeIdGroups, offlinePeriods, gameState, openUpgradePicker, openProdSwitcherModal, purchasesPassTimeLimit} 
+    : I_TimeGroupList)
     : JSX.Element {
 
     let groupStartPos = 1;
 
     return <>
-        { timeIdGroups.map((data, idx) => {
-            if(data.timeId > MAX_TIME){
-                return null;
-            }
+            { timeIdGroups.map((data, idx) => {
+                if(data.timeId > MAX_TIME){
+                    return null;
+                }
 
-            const displaySwitches = data.switches.filter(ele => {
-                return data.productionSettings[ele.key as keyof typeof data.productionSettings] !== ele.to;
-            });
+                const displaySwitches = data.switches.filter(ele => {
+                    return data.productionSettings[ele.key as keyof typeof data.productionSettings] !== ele.to;
+                });
 
-            let startPos = groupStartPos;
-            groupStartPos += data.upgrades.length;
-            let nextPos = groupStartPos;
+                let startPos = groupStartPos;
+                groupStartPos += data.upgrades.length;
+                let nextPos = groupStartPos;
 
-            return <div key={'tgcr' + idx} className={"w-min"}>
-                        <TimeGroup 
-                            groupData={data} 
-                            startPos={startPos} 
-                            openUpgradePicker={ openUpgradePicker } 
-                            offlinePeriods={offlinePeriods} 
-                            gameState={gameState} 
-                            remainingGroups={timeIdGroups.slice(idx + 1)}
-                        />
-                        <ControlsRow
-                            displaySwitches={displaySwitches}
-                            handleProductionClick={() => openProdSwitcherModal(data)} 
-                            handleUpgradeClick={() => openUpgradePicker(nextPos - 1)}
-                            showUpgradeButton={ idx < timeIdGroups.length - 1 || purchasesPassTimeLimit }
-                        />
-                    </div>
-            // return <Fragment key={'tgcr' + idx}>
-            //             <TimeGroup 
-            //                 groupData={data} 
-            //                 startPos={startPos} 
-            //                 openUpgradePicker={ openUpgradePicker } 
-            //                 offlinePeriods={offlinePeriods} 
-            //                 gameState={gameState} 
-            //                 remainingGroups={timeIdGroups.slice(idx + 1)}
-            //             />
-            //             <ControlsRow
-            //                 displaySwitches={displaySwitches}
-            //                 handleProductionClick={() => openProdSwitcherModal(data)} 
-            //                 handleUpgradeClick={() => openUpgradePicker(nextPos - 1)}
-            //                 showUpgradeButton={ idx < timeIdGroups.length - 1 || purchasesPassTimeLimit }
-            //             />
-            //         </Fragment>
-        })}
+                return <div key={'tgcr' + idx} className={"w-min"}>
+                            <TimeGroup 
+                                groupData={data} 
+                                startPos={startPos} 
+                                openUpgradePicker={ openUpgradePicker } 
+                                offlinePeriods={offlinePeriods} 
+                                gameState={gameState} 
+                                remainingGroups={timeIdGroups.slice(idx + 1)}
+                            />
+                            <ControlsRow
+                                displaySwitches={displaySwitches}
+                                handleProductionClick={() => openProdSwitcherModal(data)} 
+                                handleUpgradeClick={() => openUpgradePicker(nextPos - 1)}
+                                showUpgradeButton={ idx < timeIdGroups.length - 1 || purchasesPassTimeLimit }
+                            />
+                        </div>
+            })}
         </>
 }

--- a/app/components/resultAtTop.tsx
+++ b/app/components/resultAtTop.tsx
@@ -25,7 +25,7 @@ export default function ResultAtTop({planData, gameState, actions, timeIdGroups}
             : "bg-red-700 text-white";
 
     return(
-        <div className={"sticky top-12 md:top-[7.5rem] shadow-md py-2 flex flex-col items-center w-full" + " " + conditionalCSS}>
+        <div className={"sticky top-12 md:top-[7.5rem] shadow-md py-2 flex flex-col items-center w-full mb-4" + " " + conditionalCSS}>
             <div className={"font-bold text-lg"}>
                 { resultOfPlan.hasWon ? "" : "NOT ENOUGH FOR " }1ST PRIZE
             </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,7 @@ import { defaultActionsList, defaultLevels, defaultStockpiles } from './utils/de
 import { MAX_TIME, SAVE_FILE_PREFIX, deepCopy, TAILWIND_MD_BREAKPOINT } from './utils/consts';
 import getPlanData from './utils/getPlanData';
 import { groupByTimeId } from './utils/groupByTimeId';
-import { T_TimeGroup, T_OfflinePeriod, T_GameState, T_Action, T_InterruptProductionSettings, T_SwitchData, T_PremiumInfo, T_ViewToggle, T_PurchaseData } from './utils/types';
+import { T_TimeGroup, T_OfflinePeriod, T_GameState, T_Action, T_ProductionSettingsNow, T_SwitchData, T_PremiumInfo, T_ViewToggle, T_PurchaseData } from './utils/types';
 import useForcedVisibilityOnDesktop from './utils/useForcedVisibilityOnDesktop';
 
 import Planner from './components/planner';
@@ -22,7 +22,7 @@ export default function Home() {
   const [gameState, setGameState] = useState<T_GameState>(defaultGameState());
   const [offlinePeriods, setOfflinePeriods] = useState<T_OfflinePeriod[]>([]);
   const [actions, setActions] = useState<T_Action[]>(defaultActionsList());
-  const [prodSettingsAtTop, setProdSettingsAtTop] = useState<T_InterruptProductionSettings | null>(null);
+  const [prodSettingsNow, setProdSettingsNow] = useState<T_ProductionSettingsNow | null>(null);
   
   const [showSaveModal, setShowSaveModal] = useState(false);
   const [showLoadModal, setShowLoadModal] = useState(false);
@@ -30,8 +30,8 @@ export default function Home() {
   const [showOfflinePeriodsModal, setShowOfflinePeriodsModal] = useState<boolean>(false);
   const [offlinePeriodIdxEdit, setOfflinePeriodIdxEdit] = useState<number | null>(null);
 
-  const [purchaseData, setPurchaseData] = useState<T_PurchaseData[] | undefined>(getPlanData({ gameState, actions, offlinePeriods, prodSettingsAtTop })?.purchaseData);
-  const [switchData, setSwitchData] = useState<T_SwitchData | undefined>(getPlanData({ gameState, actions, offlinePeriods, prodSettingsAtTop })?.switchData);
+  const [purchaseData, setPurchaseData] = useState<T_PurchaseData[] | undefined>(getPlanData({ gameState, actions, offlinePeriods, prodSettingsNow })?.purchaseData);
+  const [switchData, setSwitchData] = useState<T_SwitchData | undefined>(getPlanData({ gameState, actions, offlinePeriods, prodSettingsNow })?.switchData);
 
   const [showGameState, setShowGameState] = useState(window.innerWidth >= TAILWIND_MD_BREAKPOINT);
   const [showOfflinePeriods, setShowOfflinePeriods] = useState(window.innerWidth >= TAILWIND_MD_BREAKPOINT);
@@ -118,7 +118,7 @@ export default function Home() {
 ]
 
   useEffect(() => {
-    let planAndSwitchData = getPlanData({ gameState, actions, offlinePeriods, prodSettingsAtTop });
+    let planAndSwitchData = getPlanData({ gameState, actions, offlinePeriods, prodSettingsNow });
     if(planAndSwitchData === null){
       return;
     }
@@ -126,7 +126,7 @@ export default function Home() {
     setPurchaseData(planAndSwitchData.purchaseData);
     setSwitchData(planAndSwitchData.switchData);
 
-  }, [prodSettingsAtTop, actions, gameState, offlinePeriods])
+  }, [prodSettingsNow, actions, gameState, offlinePeriods])
 
   if(purchaseData === undefined || switchData === undefined){
     return null;
@@ -194,8 +194,8 @@ export default function Home() {
                       offlinePeriods={offlinePeriods} 
                       purchaseData={purchaseData}
                       timeIdGroups={timeIdGroups}
-                      prodSettingsAtTop={prodSettingsAtTop}
-                      setProdSettingsAtTop={setProdSettingsAtTop}
+                      prodSettingsNow={prodSettingsNow}
+                      setProdSettingsNow={setProdSettingsNow}
             />
         }
       </div>

--- a/app/utils/editPlan.tsx
+++ b/app/utils/editPlan.tsx
@@ -47,6 +47,7 @@ export function moveIsValid({srcIdx, dstIdx, purchaseData}
     }
 }
 
+
 interface I_SwapIsValidWithReason extends Pick<I_MoveIsValid, "purchaseData"> {
     idxBefore : number,
     idxAfter : number,

--- a/app/utils/types.tsx
+++ b/app/utils/types.tsx
@@ -122,7 +122,7 @@ export type T_ProductionSettings = {
     rex : string,
 }
 
-export type T_InterruptProductionSettings = 
+export type T_ProductionSettingsNow = 
     Pick<T_PurchaseData, "timeId"> &
     Pick<T_PurchaseData, "productionSettings">;
 
@@ -155,4 +155,11 @@ export type T_ViewToggle = {
     displayStr : string,
     value : any,
     toggle : () => void
+}
+
+
+export interface I_ProductionSwitcherModalUniversal {
+    isVisible : boolean,
+    closeModal : () => void,
+    updateProdSettings : (newSettings : T_ProductionSettings) => void,
 }

--- a/app/utils/useSwitchProductionFuture.tsx
+++ b/app/utils/useSwitchProductionFuture.tsx
@@ -1,0 +1,95 @@
+/*
+    Hook to support operation of the production switch modal.
+
+    Note: suitable for all "switch" buttons, with one exception: the first switch button, at the top.
+    That one requires useSwitchProductionNow.
+
+    ---
+
+    Assumption: while users /could/ switch production at any time they please, it's unlikely that they'll
+    have a burning desire to switch to producing, say, green at precisely 16:32. It'd make more sense for
+    them to want to do it at one of these three times:
+        1) When they've just purchased an upgrade and they'd benefit from different settings going forwards
+        2) Now (e.g. it's mid-event, they just realised they're producing the wrong thing and they want to 
+           see how badly that's messed up their performance and whether they can fix it)
+        3) Once a particular quantity of eggs have been produced
+
+    This hook is intended for case #1, which can be planned in advance. It adds production switches to the 
+    list of planned 'actions', which will cause it to be applied to the plan after the preceeding upgrade 
+    is complete.
+*/
+import { useState } from 'react';
+
+import { deepCopy } from './consts';
+import { removeAllSwitchActionsInTimeGroup, countInternalProductionSwitches, getNewSwitchActions } from './productionSettings';
+import { I_ProductionSwitcherModalUniversal, T_ProductionSettings, T_TimeGroup, T_Action } from './types';
+
+
+interface I_UseSwitchProductionFuture {
+    actions : T_Action[], 
+    setActions : React.Dispatch<React.SetStateAction<T_Action[]>>, 
+}
+
+type T_OutputUseProductionSwitcher = {
+    openModal: (data : T_TimeGroup) => void,
+    props : T_PropsSwitchProdFutureModal
+}
+export type T_PropsSwitchProdFutureModal = 
+    I_ProductionSwitcherModalUniversal & {
+    data : T_TimeGroup | null,
+}
+export function useSwitchProductionFuture({actions, setActions}
+    : I_UseSwitchProductionFuture)
+    : T_OutputUseProductionSwitcher {
+
+    const [isVisible, setIsVisible] = useState(false);
+    const [targetTimeGroup, setTargetTimeGroup] = useState<T_TimeGroup | null>(null);
+
+    function openModal(data : T_TimeGroup)
+        : void {
+
+        setTargetTimeGroup(data);
+        setIsVisible(true);
+    }
+
+    function updateSettings(newSettings : T_ProductionSettings)
+        : void {
+
+        if(targetTimeGroup === null){
+            return;
+        }
+
+        let workingActions = deepCopy(actions);
+        let numInternalSwitches = 0;
+
+        if(targetTimeGroup.switches.length > 0){
+            workingActions = removeAllSwitchActionsInTimeGroup({ timeGroupData: targetTimeGroup, workingActions });
+            numInternalSwitches = countInternalProductionSwitches({ timeGroupData: targetTimeGroup });
+        }
+
+        let lastUpgrade = targetTimeGroup.upgrades[targetTimeGroup.upgrades.length - 1];
+        let insertIdx = lastUpgrade.actionsIdx + 1 - numInternalSwitches;
+
+        let newSwitchActions = getNewSwitchActions({
+            startSettings: targetTimeGroup.productionSettings,
+            newSettings,
+            insertIdx
+        });
+
+        workingActions = workingActions.slice(0, insertIdx).concat(newSwitchActions).concat(workingActions.slice(insertIdx));  
+        setActions(workingActions);
+    }
+
+
+    let props : T_PropsSwitchProdFutureModal = {
+        isVisible: isVisible,
+        closeModal: () => setIsVisible(false),
+        data: targetTimeGroup,
+        updateProdSettings: updateSettings
+    }
+
+    return {
+        openModal: openModal,
+        props,
+    }
+}

--- a/app/utils/useSwitchProductionNow.tsx
+++ b/app/utils/useSwitchProductionNow.tsx
@@ -1,0 +1,80 @@
+/*
+    Hook for production "interrupt".
+
+    Note: only to be used at the start of the plan, before the first unbought upgrade.
+    Switches anywhere else in the plan should useSwitchProductionFuture instead.
+
+    ----
+
+    Assumption: while users /could/ switch production at any time they please, it's unlikely that they'll
+    have a burning desire to switch to producing, say, green at precisely 16:32. It'd make more sense for
+    them to want to do it at one of these three times:
+        1) When they've just purchased an upgrade and they'd benefit from different settings going forwards
+        2) Now (e.g. it's mid-event, they just realised they're producing the wrong thing and they want to 
+           see how badly that's messed up their performance and whether they can fix it)
+        3) Once a particular quantity of eggs have been produced
+
+    This hook is intended for case #2. We can't guarantee that users will adjust the initial production
+    settings /immediately/ after they update their gameState, so altering the settings "now" means the 
+    production time of the first upgrade will need to account for:
+        > Stockpiles as entered in gameState
+        > One period of production from gameState.timeEntered until "now", where the old production settings apply
+        > One period of production from "now" onwards, where the new production settings apply
+
+    This requires a different calculation to the standard "actions-based" production switches, but it
+    will use the same UI component for requesting input, so as not to confuse the user with two different 
+    means of switching production.
+*/
+
+
+import { useState } from 'react';
+
+import { convertDateToTimeId } from './dateAndTimeHelpers';
+import { I_ProductionSwitcherModalUniversal, T_ProductionSettings, T_TimeGroup, T_GameState, T_Levels, T_ProductionSettingsNow } from './types';
+
+
+interface I_UseSwitchProductionNow {
+    initialProdSettings : T_ProductionSettings,
+    gameState : T_GameState, 
+    timeIdGroups : T_TimeGroup[],
+    setProdSettingsNow : React.Dispatch<React.SetStateAction<T_ProductionSettingsNow | null>>
+}
+
+export type T_PropsSwitchProdNowModal = 
+    I_ProductionSwitcherModalUniversal & {
+    initialProdSettings : T_ProductionSettings,
+    levelsAtStart : T_Levels
+}
+
+type T_OutputUseSwitchProductionNow = {
+    openModal : () => void,
+    props : T_PropsSwitchProdNowModal,
+}
+export function useSwitchProductionNow({initialProdSettings, setProdSettingsNow, gameState, timeIdGroups}
+    : I_UseSwitchProductionNow)
+    : T_OutputUseSwitchProductionNow {
+
+    const [isVisible, setIsVisible] = useState(false);
+
+    function updateSettings(newSettings : T_ProductionSettings) 
+        : void {
+
+        setProdSettingsNow({
+            productionSettings: newSettings,
+            timeId: convertDateToTimeId(new Date(), gameState)
+        })
+    }
+
+    let props : T_PropsSwitchProdNowModal = {
+        isVisible: isVisible,
+        closeModal: () => setIsVisible(false),
+        initialProdSettings,
+        updateProdSettings: updateSettings,
+        levelsAtStart: timeIdGroups[0].levels
+    }
+
+    return {
+        openModal: () => setIsVisible(true),
+        props: props
+    }
+}

--- a/app/utils/useUpgradePicker.tsx
+++ b/app/utils/useUpgradePicker.tsx
@@ -1,0 +1,74 @@
+import { useState } from 'react';
+
+import { deepCopy } from './consts';
+import { moveIsValid, T_ValidMoveOutput } from './editPlan';
+import { T_PurchaseData, T_Action } from '../utils/types';
+
+
+interface I_UseUpgradePicker {
+    actions : T_Action[], 
+    setActions : React.Dispatch<React.SetStateAction<T_Action[]>>, 
+    purchaseData : T_PurchaseData[],
+}
+
+type T_OutputUseUpgradePicker = { 
+    openModal : (idx : number) => void, 
+    props : T_PropsUpgradePickerModal 
+}
+
+export type T_PropsUpgradePickerModal = {
+    showModal : boolean,
+    closeModal : () => void,
+    movePlanElement : (data : { oldIdx : number, newIdx : number }) => void,
+    pickerTargetIdx : number | null,
+}
+
+export function useUpgradePicker({purchaseData, actions, setActions}
+    : I_UseUpgradePicker)
+    : T_OutputUseUpgradePicker {
+
+    const [showUpgradePicker, setShowUpgradePicker] = useState(false);
+    const [pickerTargetIdx, setPickerTargetIdx] = useState<number | null>(null);
+
+    function openModal(idx : number)
+        : void {
+
+        setPickerTargetIdx(idx);
+        setShowUpgradePicker(true);
+    }
+
+    function movePlanElement({oldIdx, newIdx} 
+        : { oldIdx : number, newIdx : number }) 
+        : void {
+       
+        let validMoveCheck : T_ValidMoveOutput = moveIsValid({srcIdx: oldIdx, dstIdx: newIdx, purchaseData});
+
+        let actionsOldIdx = purchaseData[oldIdx].actionsIdx;
+        let actionsNewIdx = purchaseData[newIdx].actionsIdx;
+
+        if(validMoveCheck.isValid){
+            let upgradeOrderDeepCopy = deepCopy(actions);
+            let targetElement = upgradeOrderDeepCopy[actionsOldIdx];
+
+            upgradeOrderDeepCopy.splice(actionsOldIdx, 1);
+            upgradeOrderDeepCopy.splice(actionsNewIdx, 0, targetElement);
+
+            setActions(upgradeOrderDeepCopy);
+        }
+        else {
+            console.log(`TODO: response to invalid move (${validMoveCheck.reason})`);
+        }
+    }
+
+    let props : T_PropsUpgradePickerModal = {
+        showModal: showUpgradePicker,
+        closeModal: () => setShowUpgradePicker(false),
+        movePlanElement: movePlanElement,
+        pickerTargetIdx: pickerTargetIdx
+    }
+
+    return {
+        openModal,
+        props
+    }
+}


### PR DESCRIPTION
> Insert button moved to left side, for more balanced composition
  in desktop mode
> Planner refactored to move modal logic into hooks
> Production Switches renamed to "future" and "now", to better
  communicate the difference between them