### PR TITLE
Form formatting adjustments

### DIFF
--- a/app/components/buttons.tsx
+++ b/app/components/buttons.tsx
@@ -94,6 +94,7 @@ function getValidType(htmlType : string | undefined)
 }
 
 
+
 interface I_MoreButtonContainer {
     showMore : boolean,
     setShowMore : React.Dispatch<React.SetStateAction<boolean>>,
@@ -101,6 +102,38 @@ interface I_MoreButtonContainer {
 }
 export function MoreButton({showMore, setShowMore, modeKey,} 
     : I_MoreButtonContainer)
+    : JSX.Element {
+
+    return  <RoundToggleButtonWrapper
+                showMore={showMore}
+                setShowMore={setShowMore}
+                modeKey={modeKey}
+                extraCSS={""}
+                >
+                <span aria-hidden={true}>...</span>
+                <span className={"sr-only"}>more info</span>
+            </RoundToggleButtonWrapper>
+}
+
+
+export function InfoButton({showMore, setShowMore, modeKey,} 
+    : I_MoreButtonContainer)
+    : JSX.Element {
+
+    return <RoundToggleButtonWrapper
+                showMore={showMore}
+                setShowMore={setShowMore}
+                modeKey={modeKey}
+                extraCSS={"font-serif text-xl leading-none items-center"}
+                >
+                <span aria-hidden={true}>i</span>
+                <span className={"sr-only"}>see stockpiles</span>
+            </RoundToggleButtonWrapper>
+}
+
+
+function RoundToggleButtonWrapper({showMore, setShowMore, modeKey, extraCSS, children} 
+    : I_MoreButtonContainer & { extraCSS : string, children : React.ReactNode })
     : JSX.Element {
 
     const onOffKey = showMore ? 'toggledOn' : 'main';
@@ -114,17 +147,13 @@ export function MoreButton({showMore, setShowMore, modeKey,}
         colourTheme = COLOURS.more;
     }
     let CSS = colourTheme[onOffKey];
-    
-    return (
-        
-            <button className={"border-2 rounded-full flex align-center justify-center w-7 h-7" + " " + CSS} 
-                    onClick={() => setShowMore(prev => !prev)}
-                    type={'button'}
-                    >
-                <span aria-hidden={true}>...</span>
-                <span className={"sr-only"}>more info</span>
+
+    return  <button className={"rounded-full border-2 flex justify-center w-7 h-7" + " " + CSS + " " + extraCSS} 
+                onClick={() => setShowMore(prev => !prev)}
+                type={'button'}
+                >
+                { children }
             </button>
-       
-    )
 }
+
 

--- a/app/components/fieldsetWrapper.tsx
+++ b/app/components/fieldsetWrapper.tsx
@@ -1,0 +1,14 @@
+interface I_FieldsetWrapper {
+    children : React.ReactNode
+}
+export default function FieldsetWrapper({children}
+    : I_FieldsetWrapper)
+    : JSX.Element {
+
+
+    return  <fieldset className={"relative rounded-sm max-w-full w-full pb-2 border border-violet-200 bg-violet-50 bg-opacity-40"}>
+                { children }
+            </fieldset>
+}
+
+

--- a/app/components/inputGameState_general.tsx
+++ b/app/components/inputGameState_general.tsx
@@ -9,6 +9,7 @@ import { capitalise } from '../utils/formatting';
 import Select from './select';
 import { Button } from './buttons';
 import { formatValueStr, getUpgradeOptions, InputNumberAsText, Label } from "./inputGameState"
+import FieldsetWrapper from "./fieldsetWrapper";
 
 
 export interface I_InputGeneral extends I_TimeRemainingFieldset, I_Entered, I_AllEggs, I_AdBoost {}
@@ -113,7 +114,7 @@ function TimeRemainingFieldset({timeRemaining, setTimeRemaining}
     const { isError, message, handleChangeDays, handleChangeHours, handleChangeMinutes } = useTimeRemainingFieldset({timeRemaining, setTimeRemaining});
 
     return (
-        <fieldset className={"relative rounded-sm max-w-full w-full pb-2 border border-violet-200 bg-violet-50 bg-opacity-40" + " " + ""}>
+        <FieldsetWrapper>
             <Label extraCSS={"font-semibold w-min px-1"} htmlFor={''} tagName={'legend'}>Time&nbsp;Remaining</Label>
             <div className={'w-full relative flex flex-col items-center gap-1 px-3 ml-1'}>
                 <div className={'w-full flex gap-2 mt-1  py-1 px-2 rounded-md'}>
@@ -126,7 +127,7 @@ function TimeRemainingFieldset({timeRemaining, setTimeRemaining}
                     : null
                 }
             </div>
-        </fieldset>
+        </FieldsetWrapper>
     )
 }
 

--- a/app/components/inputGameState_general.tsx
+++ b/app/components/inputGameState_general.tsx
@@ -73,24 +73,34 @@ function Entered({timeEntered, setStateOnChange, setTimeEntered}
     timeEntered = timeEntered ?? new Date();
 
     return(
-        <div className={"flex gap-2 items-center"}>
-            <Label htmlFor={"id_timeEntered"}>Entered</Label>
-            <p suppressHydrationWarning={true}>{ getDateDisplayStr(timeEntered) }</p>
-            <input hidden type="datetime-local" id={"id_timeEntered"} value={timeEntered == null ? "" : `${timeEntered}`} onChange={(e) => setStateOnChange(e, setTimeEntered)}/>
+        <div className={"flex items-center gap-2"}>
 
-            <Button 
-                htmlType={"button"}
-                onClick={() => { setTimeEntered(new Date()) }}
-                colours={"secondary"}
-                size={"inline"}
-                extraCSS={"ml-3"}
-            >
-                &laquo;&nbsp;now
-            </Button>
+            <Label htmlFor={"id_timeEntered"}>Entered</Label>
+                <Button 
+                    htmlType={"button"}
+                    onClick={() => { setTimeEntered(new Date()) }}
+                    colours={"secondary"}
+                    size={"inline"}
+                    extraCSS={"w-min"}
+                    >
+                    now
+                </Button>
+                <p 
+                    suppressHydrationWarning={true} 
+                    className={"ml-2"}
+                    >
+                    { getDateDisplayStr(timeEntered) }
+                </p>
+                <input 
+                    hidden 
+                    type="datetime-local" 
+                    id={"id_timeEntered"} 
+                    value={timeEntered == null ? "" : `${timeEntered}`} 
+                    onChange={(e) => setStateOnChange(e, setTimeEntered)}
+                />
         </div>
     )
 }
-
 
 interface I_TimeRemainingFieldset {
     timeRemaining: T_TimeRemainingDHM,
@@ -103,10 +113,10 @@ function TimeRemainingFieldset({timeRemaining, setTimeRemaining}
     const { isError, message, handleChangeDays, handleChangeHours, handleChangeMinutes } = useTimeRemainingFieldset({timeRemaining, setTimeRemaining});
 
     return (
-        <fieldset className={"relative w-full pt-5" + " " + ""}>
-            <Label extraCSS={"absolute top-0 font-semibold"} htmlFor={''} tagName={'legend'}>Remaining</Label>
-            <div className={'relative flex flex-col items-center gap-1 px-3 ml-1'}>
-                <div className={'flex justify-center gap-2 mt-1'}>
+        <fieldset className={"relative rounded-sm max-w-full w-full pb-2 border border-violet-200 bg-violet-50 bg-opacity-40" + " " + ""}>
+            <Label extraCSS={"font-semibold w-min px-1"} htmlFor={''} tagName={'legend'}>Time&nbsp;Remaining</Label>
+            <div className={'w-full relative flex flex-col items-center gap-1 px-3 ml-1'}>
+                <div className={'w-full flex gap-2 mt-1  py-1 px-2 rounded-md'}>
                     <TimeRemainingUnit unitName={"days"} value={timeRemaining == null ? 0 : timeRemaining.days} handleChange={handleChangeDays} />
                     <TimeRemainingUnit unitName={"hours"} value={timeRemaining == null ? 0 : timeRemaining.hours} handleChange={handleChangeHours} />
                     <TimeRemainingUnit unitName={"minutes"} value={timeRemaining == null ? 0 : timeRemaining.minutes} handleChange={handleChangeMinutes} />
@@ -119,6 +129,7 @@ function TimeRemainingFieldset({timeRemaining, setTimeRemaining}
         </fieldset>
     )
 }
+
 
 interface I_TimeRemainingUnitProps {
     unitName : string, 
@@ -135,14 +146,12 @@ function TimeRemainingUnit({unitName, value, handleChange}
 
     const idStr = `id_${unitName}`;
     return (
-        <div className={'flex items-center'}>
-            <InputNumberAsText cssStr={"w-12 pl-1"} idStr={idStr} value={value} handleChange={handleChange} />
-            <label className={"pl-1 pr-2"} htmlFor={idStr}>{unitName.charAt(0)}</label>
+        <div className={'flex items-center justify-items-stretch w-1/3'}>
+            <InputNumberAsText cssStr={"w-12 pl-1 bg-white"} idStr={idStr} value={value} handleChange={handleChange} />
+            <label className={"pl-1 pr-2 w-4"} htmlFor={idStr}>{unitName.charAt(0)}</label>
         </div>
     )
 }
-
-
 
 
 type T_OutputUseTimeRemainingFieldset = {

--- a/app/components/inputOfflinePeriods.tsx
+++ b/app/components/inputOfflinePeriods.tsx
@@ -7,8 +7,9 @@ import { T_OfflinePeriod, T_GameState, T_TimeOfflinePeriod } from '../utils/type
 import { generateKey } from '../utils/uniqueKeys';
 
 import Modal, { ModalHeading, ModalSubHeading, ModalFieldsWrapper } from './modal';
-import { SelectWithLabel, T_OptionData } from './select';
+import Select, { T_OptionData } from './select';
 import { Button } from './buttons';
+import FieldsetWrapper from './fieldsetWrapper';
 
 /*
     Note: the dates on offline period times must be stored as an offset to the 
@@ -117,7 +118,9 @@ export default function OfflineForm({closeForm, offlinePeriod, gameState, pos, s
 
 
 function ErrorMessage(){
-    return <p className={"text-sm border-1 text-neutral-700 px-1 py-1 w-56"}>Error: offline period ends before it starts</p>
+    return  <p className={"text-sm border-l-4 border-red-500 bg-red-200 bg-opacity-30 text-black px-3 py-2"}>
+                Invalid input: offline period ends before it begins
+            </p>
 }
 
 
@@ -129,7 +132,6 @@ interface I_OfflineFormProps extends Pick<I_OfflineForm, "gameState">{
     dhm : T_TimeOfflinePeriod, 
     handleSingleKeyChange : (roleKey : string, unitKey : string, value : number) => void
 }
-
 function OfflineTimeInput({ legend, idStr, roleKey, dhm, handleSingleKeyChange, gameState, showError } 
     : I_OfflineFormProps)
     : JSX.Element {
@@ -146,46 +148,62 @@ function OfflineTimeInput({ legend, idStr, roleKey, dhm, handleSingleKeyChange, 
     } = offlineTimesInputKit({ handleSingleKeyChange, roleKey, gameState });
 
 
-    const LABEL_CSS = "pl-2 pr-1 text-sm";
     return (
-        <fieldset>
-            <legend className={"font-semibold ml-2 mb-1"}>{legend}</legend>
+        <FieldsetWrapper>
+            <legend className={"font-semibold ml-2 mb-1 px-1"}>{legend}</legend>
             <div className={"flex flex-nowrap text-sm items-center"}>
-                <SelectWithLabel
+                <SelectOffline
                     id={ID_D}
-                    labelDisplay={"d"}
-                    labelExtraCSS={LABEL_CSS}
                     selectExtraCSS={undefined}
                     handleChange={handleDateChange}
                     initValue={validDates[dhm.dateOffset].date.toString()}
                     options={convertValidDatesToOptions(validDates)} 
+                    visualLabel={""}
+                    srLabel={"date"}
+                    extraCSS={"pl-2 pr-1"}
                 />
-                <SelectWithLabel
+                <SelectOffline
                     id={ID_H}
-                    labelDisplay={"h"}
-                    labelExtraCSS={LABEL_CSS}
                     selectExtraCSS={undefined}
                     handleChange={(e : ChangeEvent<HTMLSelectElement>) => handleSingleKeyChange(roleKey, 'hours', parseInt(e.target.value))}
                     initValue={dhm.hours.toString()}
                     options={calcOptionsForNumberRange(0, 23)} 
+                    visualLabel={""}
+                    srLabel={"time: hour"}
+                    extraCSS={"px-2"}
                 />
-                <SelectWithLabel
+                <SelectOffline
                     id={ID_M}
-                    labelDisplay={"m"}
-                    labelExtraCSS={LABEL_CSS}
                     selectExtraCSS={undefined}
                     handleChange={(e : ChangeEvent<HTMLSelectElement>) => handleSingleKeyChange(roleKey, 'minutes', parseInt(e.target.value))}
                     initValue={dhm.minutes.toString()}
                     options={calcOptionsForNumberRange(0, 59)} 
+                    visualLabel={":"}
+                    srLabel={"time@ minute"}
+                    extraCSS={"px-1"}
                 />
                 {
                     showError ?
-                        <span className={"ml-2 text-red-500 font-bold font-lg"}>X</span>
+                        <span className={"ml-5 text-red-500 font-bold text-xl"}>X</span>
                         : null
                 }
             </div>
-        </fieldset>
+        </FieldsetWrapper>
     )
+}
+
+
+function SelectOffline({id, selectExtraCSS, options, handleChange, initValue, visualLabel, srLabel, extraCSS}
+    : any)
+    : JSX.Element {
+
+    return <div>
+        <label htmlFor={id} className={"text-sm" + " " + extraCSS}>
+            <span className={"sr-only"}>{srLabel}</span>
+            <span aria-hidden={true}>{visualLabel}</span>
+        </label>
+        <Select id={id} selectExtraCSS={selectExtraCSS} options={options} handleChange={handleChange} initValue={initValue} />
+    </div>
 }
 
 

--- a/app/components/inputUpgradePicker.tsx
+++ b/app/components/inputUpgradePicker.tsx
@@ -10,7 +10,7 @@ import { BadgeCost, BadgeMaxed } from "./badges";
 
 import Modal, { ModalHeading, ModalSubmitButton, I_Modal, ModalFieldsWrapper } from './modal';
 import Radio from './radio';
-import { MoreButton } from "./buttons";
+import { MoreButton, InfoButton } from "./buttons";
 import StockpilesDisplay from "./stockpilesStrip";
 import Tooltip from './tooltip';
 
@@ -83,7 +83,7 @@ function MoreInfo({stockpiles}
 
     return  <div className={"relative flex justify-end"}>                             
                 <div className={"self-end relative top-3"}>
-                    <MoreButton showMore={showStockpiles} setShowMore={setShowStockpiles} modeKey={'primary'} />
+                    <InfoButton showMore={showStockpiles} setShowMore={setShowStockpiles} modeKey={'primary'} />
                 </div>
                 { showStockpiles ?
                     <Tooltip close={() => setShowStockpiles(false)} >


### PR DESCRIPTION
UpgradePicker form
The use of the "more" button for toggling information about stockpiles was questionable. Altered it to display an "i for information" instead of "...".

GameState form
The "general" page has never looked quite right. Made two changes to improve it:
* Entered: swapped the order of the "now" button and the current entered time/date, so all the "actions" are aligned vertically
* Remaining: added some fieldset formatting around the inputs

OfflinePeriods form
* For consistency, moved the new fieldset from GameState into its own file, then applied it to the fieldsets here as well as gameState
* Fixed inconsistent use of the "dhm" labels - on the gameState form they meant "days remaining, hours remaining, minutes remaining", while on offlinePeriods they meant "date, hour on the clock, minute on the clock". Since the actual game displays time remaining in terms of "dhm", I altered the offline periods form
* The new labels would be useless for screenreaders, so added SR-only labels for clarity
