### PR TITLE
Update formatting and aria on modals

### DIFF
--- a/app/components/fieldsetWrapper.tsx
+++ b/app/components/fieldsetWrapper.tsx
@@ -5,8 +5,9 @@ export default function FieldsetWrapper({children}
     : I_FieldsetWrapper)
     : JSX.Element {
 
-
-    return  <fieldset className={"relative rounded-sm max-w-full w-full pb-2 border border-violet-200 bg-violet-50 bg-opacity-40"}>
+    return  <fieldset 
+                className={"relative rounded-sm max-w-full w-11/12 pb-2 border border-violet-200 bg-violet-50 bg-opacity-40"}
+                >
                 { children }
             </fieldset>
 }

--- a/app/components/inputGameState.tsx
+++ b/app/components/inputGameState.tsx
@@ -44,10 +44,12 @@ export default function StatusForm({setGameState, gameState, closeModal}
 
     return (
         <Modal closeModal={closeModal}>
-            <ModalHeading>Enter Game Status</ModalHeading>
-
+            <ModalHeading>Game Status</ModalHeading>
             <form onSubmit={(e) => onSubmit(e)}>
-                <InputPageWrapper isVisible={ activePage === 1 } heading={`1/${MAX_PAGE_NUM}: Times and Premium`} >
+                <InputPageWrapper isVisible={ activePage === 1 } heading={`1/${MAX_PAGE_NUM}: Times and Premium`} 
+                    activePage={activePage} setActivePage={setActivePage}
+                    >
+
                     <InputGeneral
                         timeEntered={timeEntered}
                         setStateOnChange={setStateOnChange}
@@ -61,14 +63,18 @@ export default function StatusForm({setGameState, gameState, closeModal}
                     />
                 </InputPageWrapper>
 
-                <InputPageWrapper isVisible={ activePage === 2 } heading={`2/${MAX_PAGE_NUM}: Current Stockpiles`} >
+                <InputPageWrapper isVisible={ activePage === 2 } heading={`2/${MAX_PAGE_NUM}: Current Stockpiles`}  
+                    activePage={activePage} setActivePage={setActivePage}
+                    >
                     <InputStockpiles
                         controlledStockpileValue={controlledStockpileValue}
                         updateStockpiles={updateStockpiles}
                     />
                 </InputPageWrapper>
 
-                <InputPageWrapper isVisible={ activePage === 3 } heading={`3/${MAX_PAGE_NUM}: Worker Levels`} >
+                <InputPageWrapper isVisible={ activePage === 3 } heading={`3/${MAX_PAGE_NUM}: Worker Levels`}  
+                    activePage={activePage} setActivePage={setActivePage}
+                    >
                     <InputLevelsWorkers
                         handleLevelChange={handleLevelChange} 
                         gameState={gameState} 
@@ -76,7 +82,9 @@ export default function StatusForm({setGameState, gameState, closeModal}
                     />
                 </InputPageWrapper>
 
-                <InputPageWrapper isVisible={ activePage === MAX_PAGE_NUM } heading={`4/${MAX_PAGE_NUM}: Other Levels`} >
+                <InputPageWrapper isVisible={ activePage === MAX_PAGE_NUM } heading={`4/${MAX_PAGE_NUM}: Other Levels`}  
+                    activePage={activePage} setActivePage={setActivePage}
+                    >
                     <InputLevelsOther
                         handleLevelChange={handleLevelChange} 
                         gameState={gameState} 
@@ -84,8 +92,8 @@ export default function StatusForm({setGameState, gameState, closeModal}
                     />
                 </InputPageWrapper>
 
-                <ModalMultiPageNav activePage={activePage} changePage={setActivePage} numPages={MAX_PAGE_NUM} />
-                <ModalSubmitButton label={"submit"} extraCSS={'sr-only [padding:0]'} disabled={false}/>
+                <ModalMultiPageNav activePage={activePage} changePage={setActivePage} numPages={MAX_PAGE_NUM} submitLabel={"enter"}/>
+                <ModalSubmitButton label={"submit"} extraCSS={'sr-only [padding:0] [height:0]'} disabled={false}/>
             </form>
         </Modal>
     )
@@ -94,7 +102,7 @@ export default function StatusForm({setGameState, gameState, closeModal}
 
 
 function InputPageWrapper({ isVisible, heading, children }
-    : { isVisible : boolean, heading? : string, children : React.ReactNode })
+    : { isVisible : boolean, heading? : string, children : React.ReactNode } & any)
     : JSX.Element {
 
     const visibilityCSS = isVisible ? "" : "sr-only";

--- a/app/components/inputGameState_general.tsx
+++ b/app/components/inputGameState_general.tsx
@@ -1,10 +1,9 @@
 import { useState, Dispatch, SetStateAction } from "react";
 
-import { T_GameState, T_TimeRemainingDHM } from "../utils/types";
-
 import { MAX_DAYS } from '../utils/consts';
 import { getDateDisplayStr } from '../utils/dateAndTimeHelpers';
 import { capitalise } from '../utils/formatting';
+import { T_GameState, T_TimeRemainingDHM } from "../utils/types";
 
 import Select from './select';
 import { Button } from './buttons';
@@ -17,7 +16,7 @@ export default function InputGeneral({timeRemaining, setTimeRemaining, timeEnter
     : I_InputGeneral)
     : JSX.Element {
 
-    return  <div className={"flex flex-col gap-6"}>
+    return  <div className={"flex flex-col gap-6 mt-1"}>
                 <TimeRemainingFieldset timeRemaining={timeRemaining} setTimeRemaining={setTimeRemaining} />
                 <Entered timeEntered={timeEntered} setStateOnChange={setStateOnChange} setTimeEntered={setTimeEntered} />
                 <AllEggs gameState={gameState} handleLevelChange={handleLevelChange} />
@@ -75,33 +74,35 @@ function Entered({timeEntered, setStateOnChange, setTimeEntered}
 
     return(
         <div className={"flex items-center gap-2"}>
-
-            <Label htmlFor={"id_timeEntered"}>Entered</Label>
-                <Button 
-                    htmlType={"button"}
-                    onClick={() => { setTimeEntered(new Date()) }}
-                    colours={"secondary"}
-                    size={"inline"}
-                    extraCSS={"w-min"}
-                    >
-                    now
-                </Button>
-                <p 
-                    suppressHydrationWarning={true} 
-                    className={"ml-2"}
-                    >
-                    { getDateDisplayStr(timeEntered) }
-                </p>
-                <input 
-                    hidden 
-                    type="datetime-local" 
-                    id={"id_timeEntered"} 
-                    value={timeEntered == null ? "" : `${timeEntered}`} 
-                    onChange={(e) => setStateOnChange(e, setTimeEntered)}
-                />
+            <Label htmlFor={"id_timeEntered"}>
+                Entered
+            </Label>
+            <Button 
+                htmlType={"button"}
+                onClick={() => { setTimeEntered(new Date()) }}
+                colours={"secondary"}
+                size={"inline"}
+                extraCSS={"w-min"}
+                >
+                now
+            </Button>
+            <p 
+                suppressHydrationWarning={true} 
+                className={"ml-2"}
+                >
+                { getDateDisplayStr(timeEntered) }
+            </p>
+            <input 
+                hidden 
+                type="datetime-local" 
+                id={"id_timeEntered"} 
+                value={timeEntered == null ? "" : `${timeEntered}`} 
+                onChange={(e) => setStateOnChange(e, setTimeEntered)}
+            />
         </div>
     )
 }
+
 
 interface I_TimeRemainingFieldset {
     timeRemaining: T_TimeRemainingDHM,
@@ -162,7 +163,6 @@ type T_OutputUseTimeRemainingFieldset = {
     handleChangeHours : (e : React.ChangeEvent<HTMLInputElement>) => void, 
     handleChangeMinutes : (e : React.ChangeEvent<HTMLInputElement>) => void, 
 }
-
 function useTimeRemainingFieldset({timeRemaining, setTimeRemaining}
     : I_TimeRemainingFieldset)
     : T_OutputUseTimeRemainingFieldset {

--- a/app/components/inputGameState_levelsOther.tsx
+++ b/app/components/inputGameState_levelsOther.tsx
@@ -39,7 +39,7 @@ export default function InputLevelsOther({gameState, levels, handleLevelChange}
 
 
     return  <>
-                <SubSection heading={"Egg Levels"}>
+                <SubSection heading={"Egg Levels"} extraCSS={"mt-0"}>
                     { productionUpgrades.map(ele => {
                             let initValue : string | undefined  = getInitValueForLevelSelect(ele.optionsProps.name, gameState);
                             let keyName = ele.optionsProps.name.toLowerCase();
@@ -82,11 +82,11 @@ export default function InputLevelsOther({gameState, levels, handleLevelChange}
 }
 
 
-function SubSection({ heading, children }
-    : { heading : string, children : React.ReactNode } )
+function SubSection({ heading, extraCSS, children }
+    : { heading : string, extraCSS? : string, children : React.ReactNode } )
     : JSX.Element {
 
-    return  <section className={"first:mt-0 mt-7"}>
+    return  <section className={extraCSS ?? "mt-7"}>
                 <h3 className={"font-semibold pb-3"}>{heading}</h3>
                 <LevelsWrapper>
                     { children }

--- a/app/components/inputGameState_stockpiles.tsx
+++ b/app/components/inputGameState_stockpiles.tsx
@@ -4,7 +4,6 @@ import { resourceCSS } from '../utils/formatting';
 import { InputNumberAsText } from "./inputGameState";
 
 export interface I_InputStockpiles extends Pick<I_StockpileInput, "controlledStockpileValue" | "updateStockpiles"> {}
-
 export default function InputStockpiles({ controlledStockpileValue, updateStockpiles } 
     : I_InputStockpiles)
     : JSX.Element {
@@ -29,11 +28,12 @@ function StockpileWrapper({coloursCSS, idStr, label, children}
     : I_PropsStockpileWrapper)
     : JSX.Element {
 
-    return  <div className={"ml-2 flex py-1 px-2 items-center border" + " " + coloursCSS}>
+    return  <div className={"rounded ml-2 flex py-1 px-2 items-center border" + " " + coloursCSS}>
                 <label className={"block w-20"} htmlFor={idStr}>{label}</label>
                 {children}
             </div>
 }
+
 
 function extractBorderColourCSS(cssStr : string){
     const regEx = /border-\w*-\d{2,3}/g;

--- a/app/components/inputProdSettings.tsx
+++ b/app/components/inputProdSettings.tsx
@@ -39,10 +39,10 @@ export default function ModalProdSettings({closeModal, currentProdSettings, curr
 
     return(
         <Modal closeModal={closeModal}>
-            <ModalHeading>Switch Production</ModalHeading>
+            <ModalHeading>Production Settings</ModalHeading>
             <form onSubmit={handleSubmit} className={"flex flex-col w-full"}>
                 <ModalFieldsWrapper>
-                    <div className={"flex flex-col items-center gap-4 mt-1"}>
+                    <div className={"flex flex-col items-center gap-6 mt-1"}>
                     {
                         Object.keys(currentProdSettings).map((myKey : string) => {
                             return <ProductionToggle key={myKey} 
@@ -55,7 +55,7 @@ export default function ModalProdSettings({closeModal, currentProdSettings, curr
                     }
                     </div>
                 </ModalFieldsWrapper>
-                <ModalSubmitButton label={"submit"} extraCSS={''} disabled={false} />
+                <ModalSubmitButton label={"set"} extraCSS={''} disabled={false} />
             </form>
         </Modal>
     )
@@ -100,18 +100,17 @@ function ProductionToggle({myKey, toggledTo, handleSelection, disabled}
                     " " + "text-gray-300"
                     : "";
     return (
-        <fieldset className={"w-32"}>
-            <legend className={"mb-1 flex items-center" + labelCSS} >
-                { capitalise(myKey) }
-                <span aria-hidden={true}>&nbsp;&raquo;&nbsp;</span>
-                <span className={"sr-only"}>currently producing</span>
+        <fieldset className={"w-full relative flex justify-end"}>
+            <legend className={"absolute top-0 left-0 mb-1 flex items-center gap-2 block" + labelCSS} >
+                <span className={"w-16 font-semibold"}>{ capitalise(myKey) }</span>
+                <span className={"sr-only"}>is producing</span>
                 {
                     disabled ?
                     <span>n/a</span>
                     : <CurrentAsCircleBadge type={toggledTo} />
                 }
             </legend>
-            <div className="flex">
+            <div className="flex w-24">
             {
                 data.outputs.map((d, idx) => {
                     return  <Radio key={`${myKey}_${d}`} 
@@ -144,13 +143,13 @@ function CurrentAsCircleBadge({type}
     let typeCSS = resourceCSS[type as keyof typeof resourceCSS];
 
     return(
-        <>
-            <div className={"inline-block w-3 h-3 rounded-full" + " " + typeCSS.badge}>             
+        <div>
+            <div className={"inline-block w-3 h-3 rounded-full border" + " " + typeCSS.badge}>             
             </div>
             <span className={"pl-1"}>
                 { type }
             </span>
-        </>
+        </div>
     )
 }
 
@@ -183,7 +182,7 @@ function ToggleDisplay({thisOption, activeOption, roundLeft, roundRight, disable
     let conditionalCSS = roundingCSS + " " + opacityCSS + " " + hoverCSS;
 
     return(
-        <div className={"duration-75 ease-linear flex justify-center content-center py-1 border-2" + " " + typeCSS.badge + " " + conditionalCSS}>
+        <div className={"duration-75 ease-linear flex justify-center content-center border-2" + " " + typeCSS.badge + " " + conditionalCSS}>
             { thisOption.charAt(0).toLowerCase() }
         </div>
     )

--- a/app/components/inputUpgradePicker.tsx
+++ b/app/components/inputUpgradePicker.tsx
@@ -7,12 +7,12 @@ import { moveIsValid } from '../utils/editPlan';
 import { T_GameState, T_PurchaseData, T_Stockpiles, T_CostData, } from "../utils/types";
 
 import { BadgeCost, BadgeMaxed } from "./badges";
-
-import Modal, { ModalHeading, ModalSubmitButton, I_Modal, ModalFieldsWrapper } from './modal';
+import Modal, { ModalHeading, ModalLegend, ModalSubmitButton, I_Modal, ModalFieldsWrapper } from './modal';
 import Radio from './radio';
-import { MoreButton, InfoButton } from "./buttons";
+import { InfoButton } from "./buttons";
 import StockpilesDisplay from "./stockpilesStrip";
 import Tooltip from './tooltip';
+
 
 export interface I_UpgradePickerModal extends Pick<I_Modal, "closeModal"> {
     movePlanElement : (data : {oldIdx : number, newIdx : number}) => void, 
@@ -20,8 +20,6 @@ export interface I_UpgradePickerModal extends Pick<I_Modal, "closeModal"> {
     purchaseData : T_PurchaseData[], 
     gameState : T_GameState
 }
-
-
 export default function UpgradePickerModal({closeModal, movePlanElement, pickerTargetIdx, purchaseData, gameState } 
     : I_UpgradePickerModal)
     {
@@ -40,14 +38,16 @@ export default function UpgradePickerModal({closeModal, movePlanElement, pickerT
 
     return(
         <Modal closeModal={closeModal}>
+            <ModalHeading>
+                Upgrade Picker
+            </ModalHeading>
             <form className={"flex flex-col items-center h-auto"} onSubmit={handleClick}>
                 <fieldset className={"flex flex-col w-full"}> 
-                    <ModalHeading tagName={'legend'}>
-                        Select Upgrade
-                    </ModalHeading>
-                    
                     <ModalFieldsWrapper>
-                        <div className={"flex flex-col items-stretch"}>
+                        <ModalLegend>
+                            Pick an upgrade for Position { pickerTargetIdx + 1 }
+                        </ModalLegend>
+                        <div className={"flex flex-col px-2"}>
                             {
                                 radioData.map((data, idx : number) => {
                                     let result = moveIsValid({srcIdx: data.fromIdx, dstIdx: pickerTargetIdx, purchaseData});
@@ -64,10 +64,13 @@ export default function UpgradePickerModal({closeModal, movePlanElement, pickerT
                                 })
                             }
                         </div>
-                        <MoreInfo stockpiles={ calcStockpilesIncludingCurrentPurchase(purchaseData[pickerTargetIdx]) } />
+                        
                     </ModalFieldsWrapper>
                 </fieldset>
-                <ModalSubmitButton label={"submit"} disabled={false} extraCSS={''} />
+                <div className={"flex w-full justify-between relative"}>
+                    <ModalSubmitButton label={"pick"} disabled={false} extraCSS={''} />
+                    <MoreInfo stockpiles={ calcStockpilesIncludingCurrentPurchase(purchaseData[pickerTargetIdx]) } />
+                </div>
             </form>
         </Modal>
 
@@ -81,26 +84,19 @@ function MoreInfo({stockpiles}
 
     const [showStockpiles, setShowStockpiles] = useState<boolean>(false);
 
-    return  <div className={"relative flex justify-end"}>                             
-                <div className={"self-end relative top-3"}>
-                    <InfoButton showMore={showStockpiles} setShowMore={setShowStockpiles} modeKey={'primary'} />
-                </div>
+    return  <div className={"flex justify-end"}>                             
+                <InfoButton showMore={showStockpiles} setShowMore={setShowStockpiles} modeKey={'primary'} />
                 { showStockpiles ?
-                    <Tooltip close={() => setShowStockpiles(false)} >
+                    <Tooltip 
+                        posAndWidthCSS={"bottom-1 right-8 z-30 w-11/12"}
+                        close={() => setShowStockpiles(false)} 
+                        >
                         <StockpilesSection stockpiles={stockpiles} />
                     </Tooltip>
                     : null
                 }
             </div>
 }
-
-{/* <button 
-className={'absolute top-0.5 right-8 z-30 border border-neutral-100 bg-white shadow-lg rounded-lg w-11/12 pt-2 pb-2.5 px-3'}
-onClick={() => setShowStockpiles(false)}
-type={'button'}
->
-<StockpilesSection stockpiles={stockpiles} />
-</button> */}
 
 
 function StockpilesSection({stockpiles} 
@@ -128,7 +124,6 @@ interface I_UpgradeRadio {
     handleSelection : () => void, 
     disabled : boolean
 }
-
 function UpgradeRadio({checked, myKey, data, handleSelection, disabled} 
     : I_UpgradeRadio)
     : JSX.Element {
@@ -212,8 +207,8 @@ function getUpgradeRadioData({ targetIdx, purchaseData, gameState }
 
     let result : T_UpgradeRadioData[] = [];
 
-    // planData[#].levels displays the level of each unit after purchasing the planned upgrade.
-    // To get the levels before purchasing the planned upgrade, consult the previous element.
+    // planData[#].levels displays the level of each unit /after/ purchasing the planned upgrade.
+    // To get the levels /before/ purchasing this planned upgrade, we must consult the previous element.
     let levelsAtStart = targetIdx === 0 ? 
                         gameState.levels
                         : purchaseData[targetIdx - 1].levels;

--- a/app/components/modal.tsx
+++ b/app/components/modal.tsx
@@ -32,7 +32,7 @@ function CloseButton({close, extraCSS}
     : I_CloseButton)
     : JSX.Element {
 
-    extraCSS = extraCSS ?? "top-2 right-2"
+    extraCSS = extraCSS ?? "top-2 right-2";
     return <button className={"absolute font-bold [&_svg]:fill-gray-500 [&_svg]:hover:fill-gray-400" + " " + extraCSS} onClick={close}>
                 <IconClose size={'20'} />
                 <span className={'sr-only'}>close</span>
@@ -48,7 +48,7 @@ export function ModalHeading({tagName, children}
                     tagName
                     :'h2' as keyof JSX.IntrinsicElements;
 
-    return  <Tag className={"font-bold text-lg pl-0.5 mt-2 self-start w-full border-b border-violet-500"}>
+    return  <Tag className={"font-bold text-lg mt-2 pl-0.5 self-start w-full border-b border-violet-500"}>
                 {children}
             </Tag>
 }
@@ -68,6 +68,16 @@ export function ModalSubHeading({tagName, children}
 }
 
 
+export function ModalLegend({children} 
+    : { children : React.ReactNode })
+    : JSX.Element {
+
+    return  <legend className={"pl-0.5 font-semibold mb-4 text-base"}>
+                {children}
+            </legend>
+}       
+
+
 export function ModalFieldsWrapper({children}
     : { children : React.ReactNode })
     : JSX.Element {
@@ -83,9 +93,9 @@ export function ModalSubmitButton({label, extraCSS, disabled}
     : JSX.Element {
 
     return <Button 
-                extraCSS={"justify-self-end w-full" + " " + extraCSS} 
+                extraCSS={extraCSS} 
                 colours={"primary"}
-                size={"full"}
+                size={"default"}
                 disabled={disabled}
                 >
                 { label ?? "submit" }
@@ -96,21 +106,22 @@ export function ModalSubmitButton({label, extraCSS, disabled}
 interface I_ModalMultiPageNav {
     activePage : number, 
     numPages : number, 
-    changePage : Dispatch<SetStateAction<number>>
+    changePage : Dispatch<SetStateAction<number>>,
+    submitLabel? : string
 }
-export function ModalMultiPageNav({activePage, numPages, changePage}
+export function ModalMultiPageNav({activePage, numPages, changePage, submitLabel}
     : I_ModalMultiPageNav)
     : JSX.Element {
 
     return  <div aria-hidden={true} className={"flex flex-col justify-center gap-5"}>
-                <NavButtonBox activePage={activePage} numPages={numPages} changePage={changePage} />
+                <NavButtonBox activePage={activePage} numPages={numPages} changePage={changePage} submitLabel={submitLabel} />
                 <ProgressStatus activePage={activePage} numPages={numPages} changePage={changePage} />
             </div>
 
 }
 
 
-function NavButtonBox({activePage, numPages, changePage}
+function NavButtonBox({activePage, numPages, changePage, submitLabel}
     : I_ModalMultiPageNav)
     : JSX.Element {
 
@@ -118,15 +129,6 @@ function NavButtonBox({activePage, numPages, changePage}
 
     return  <div className={"flex justify-center"}>
                 <div className={"flex justify-between w-full"}>
-                    <Button
-                        colours={'secondary'}
-                        htmlType={'button'}
-                        size={'twin'}
-                        onClick={() => activePage === 1 ? undefined : changePage(activePage - 1)}
-                        disabled={activePage === 1}
-                    >
-                        &laquo;&nbsp;previous
-                    </Button>
                     {
                         isLastPage ?
                             <Button
@@ -136,8 +138,9 @@ function NavButtonBox({activePage, numPages, changePage}
                                 size={'twin'}
                                 onClick={undefined}
                                 disabled={false}
+                                extraCSS={"border-2"}
                             >
-                                submit
+                                { submitLabel ?? "submit" }
                             </Button>
                         :
                             <Button
@@ -147,10 +150,20 @@ function NavButtonBox({activePage, numPages, changePage}
                                 size={'twin'}
                                 onClick={() => changePage(activePage + 1)}
                                 disabled={isLastPage}
+                                extraCSS={"border-2"}
                             >
                                 next&nbsp;&raquo;
                             </Button>
                     }
+                    <Button
+                        colours={'secondary'}
+                        htmlType={'button'}
+                        size={'twin'}
+                        onClick={() => activePage === 1 ? undefined : changePage(activePage - 1)}
+                        disabled={activePage === 1}
+                        >
+                        &laquo;&nbsp;back
+                    </Button>
                 </div>
             </div>
 }

--- a/app/components/sectionOfflinePeriods.tsx
+++ b/app/components/sectionOfflinePeriods.tsx
@@ -1,5 +1,4 @@
 import { getDateDisplayStr, getStartTime, convertOfflineTimeToDate, printOfflineTime } from "../utils/dateAndTimeHelpers";
-import { nbsp } from "../utils/formatting";
 import { T_GameState, T_OfflinePeriod } from "../utils/types";
 
 import { InputResultsSection, EditButtonBox } from './sectionInputResults';
@@ -12,7 +11,6 @@ interface I_SectionOfflinePeriods {
     openModal : (idx : number | null) => void,
     idxEdit : number | null,
 }
-
 export default function SectionOfflinePeriods({offlinePeriods, openModal, gameState, idxEdit} 
     : I_SectionOfflinePeriods)
     : JSX.Element | null {
@@ -24,7 +22,7 @@ export default function SectionOfflinePeriods({offlinePeriods, openModal, gameSt
     return  <InputResultsSection title={"Offline Periods"}>
                 <div className={'overflow-y-auto overflow-x-hidden max-h-[calc(100vh-5rem)] px-2'}>
                     <OfflineDisplay offlinePeriods={offlinePeriods} gameState={gameState} openForm={openModal} idxEdit={idxEdit} />
-                    <EditButtonBox openEditForm={() => openModal(null)} label={`+${nbsp()}more`} />
+                    <EditButtonBox openEditForm={() => openModal(null)} label={`add`} />
                 </div>
             </InputResultsSection>
 

--- a/app/components/select.tsx
+++ b/app/components/select.tsx
@@ -1,4 +1,4 @@
-interface I_SelectProps {
+export interface I_SelectProps {
     id : string,
     options : T_OptionData[],
     handleChange : (e: React.ChangeEvent<HTMLSelectElement>) => void,


### PR DESCRIPTION
* Fix top heading spacing on Upgrade Picker
* All submit buttons have more descriptive labels than "submit"
* Remove all full width buttons, replace with default width
* Move Upgrade Picker information button to be on the same "row" as the slimmer "pick" (nee submit) button
* GameState modal has "next" on the left and "back" on the right, maintainining consistency with other modals (which all have a slim primary button on the left and secondary on the right)
* Offline periods modal no longer displays "delete" button when there's nothing to delete
* Move instructions out of subheadings
* Add aria properties to Offline Periods' error message
* Reformat production settings modal to be more horizontal, so the "set" (nee submit) button doesn't look weird, sitting there on the left while everything else is centered