### PR TITLE
Refactor calc time of offline period start

### DIFF
--- a/app/utils/calcPlanData.tsx
+++ b/app/utils/calcPlanData.tsx
@@ -33,6 +33,7 @@ type T_UpgradeLoop = {
 }
 
 type T_ActiveOfflinePeriod = {
+    startTimeID : number,
     endTimeID : number,
     levels : T_Levels,
     productionSettings : T_ProductionSettings
@@ -274,6 +275,7 @@ export default function calcPlanData({ gameState, actions, offlinePeriods, prodS
             return;
         }
         activeOfflinePeriod = {
+            startTimeID: periodTimeIDs.start,
             endTimeID: periodTimeIDs.end,
             productionSettings: deepCopy(productionSettings),
             levels: deepCopy(levels),
@@ -305,7 +307,8 @@ export default function calcPlanData({ gameState, actions, offlinePeriods, prodS
             ratesDuring: deepCopy(productionRates),
             levelsAtEnd: deepCopy(levels),
             stockpilesAtEnd: deepCopy(stockpiles),
-            allToDustAfter: allToDust
+            allToDustAfter: allToDust,
+            startOfflinePeriodTimeID: activeOfflinePeriod ? activeOfflinePeriod.startTimeID : null,
         }
     }
 

--- a/app/utils/calcTimeGroups.tsx
+++ b/app/utils/calcTimeGroups.tsx
@@ -1,19 +1,15 @@
 import { deepCopy } from "./consts";
-import { T_TimeData, T_OfflinePeriod, T_PurchaseData, T_SwitchAction, T_SwitchData, T_TimeGroup } from "./types";
-import { getOfflinePeriodAsTimeIDs } from "./offlinePeriodHelpers";
+import { T_TimeData, T_PurchaseData, T_SwitchAction, T_SwitchData, T_TimeGroup, T_TimeDataUnit } from "./types";
 
 
 
 interface I_GroupByTimeID {
     purchaseData : T_PurchaseData[],
     switchData : T_SwitchData,
-    offlinePeriods : T_OfflinePeriod[],
-    startedAt : Date,
     timeData : T_TimeData
 }
 
-
-export function calcTimeGroups({purchaseData, switchData, offlinePeriods, startedAt, timeData} 
+export function calcTimeGroups({purchaseData, switchData, timeData} 
     : I_GroupByTimeID ) 
     : T_TimeGroup[]{
 
@@ -51,14 +47,8 @@ export function calcTimeGroups({purchaseData, switchData, offlinePeriods, starte
 
         let switches : T_SwitchAction[] = getSwitchesAtThisTimeID(timeID);
 
-        let startOfflinePeriodTimeID : null | number = null;
-        const offlinePeriodTimeIDs = getOfflinePeriodAsTimeIDs({ timeID: purchases[0].readyTimeID, offlinePeriods, startedAt });
-        if(offlinePeriodTimeIDs !== null){
-            startOfflinePeriodTimeID = offlinePeriodTimeIDs.start;
-        }
-
         let key = timeID.toString();
-        const timeDataThis = deepCopy(timeData[key]);
+        const timeDataThis : T_TimeDataUnit = deepCopy(timeData[key]);
 
         let newGroup = {
             timeID,
@@ -66,7 +56,6 @@ export function calcTimeGroups({purchaseData, switchData, offlinePeriods, starte
             startPos: startIdx + 1,
             upgrades: purchases,
             switches: Array.from(new Set(switches)),
-            startOfflinePeriodTimeID,
         }
 
         return newGroup;

--- a/app/utils/types.tsx
+++ b/app/utils/types.tsx
@@ -90,12 +90,13 @@ export type T_PurchaseData =
 export type T_TimeData = {
     [key : string] : T_TimeDataUnit,
 }
-type T_TimeDataUnit = {
+export type T_TimeDataUnit = {
     stockpilesAtEnd: T_Stockpiles,
     levelsAtEnd: T_Levels,
     ratesDuring: T_ProductionRates,
     productionSettingsDuring : T_ProductionSettings,
     allToDustAfter : T_AllToDustOutput,
+    startOfflinePeriodTimeID : number | null,
 }
 
 export type T_SwitchData = {
@@ -121,7 +122,6 @@ export type T_TimeGroup =
     startPos : number,
     upgrades : T_PurchaseData[],
     switches : T_SwitchAction[],
-    startOfflinePeriodTimeID : number | null
 };
 
 export type T_ProductionSettings = {

--- a/app/utils/usePlanner.tsx
+++ b/app/utils/usePlanner.tsx
@@ -35,7 +35,7 @@ export default function usePlanner(){
     
     const timeIDGroups : T_TimeGroup[] | null = purchaseData === undefined || switchData === undefined || timeData === undefined ?
         null 
-        : calcTimeGroups({purchaseData, switchData, offlinePeriods, timeData, startedAt: calcStartTime(gameState)});
+        : calcTimeGroups({purchaseData, switchData, timeData});
 
     return {
         gameState, 


### PR DESCRIPTION
Before: calcPlanData looks up the start and end timeIDs of the offline period, throws away the start time, does its thing, then calcTimeGroups needs two arguments and a function import to work out the start time itself.

Now: calcPlanData keeps the start time of the offline period too and passes that along to timeGroups together with the other data.