### PR TITLE
Improve "more" panel on timeGroups

### DIFF
--- a/app/components/planner/subcomponents/resultAtTop.tsx
+++ b/app/components/planner/subcomponents/resultAtTop.tsx
@@ -24,7 +24,7 @@ export default function ResultAtTop({gameState, actions, timeIDGroups}
             : "bg-red-700 text-white";
 
     return(
-        <div className={"sticky top-12 md:top-[7.5rem] shadow-md py-2 flex flex-col items-center w-full mb-4" + " " + conditionalCSS}>
+        <div className={"sticky z-10 top-12 md:top-[7.5rem] shadow-md py-2 flex flex-col items-center w-full mb-4" + " " + conditionalCSS}>
             <div className={"font-bold text-lg"}>
                 { resultOfPlan.hasWon ? "" : "NOT ENOUGH FOR " }1ST PRIZE
             </div>

--- a/app/components/timeGroup/timeGroupMore/subcomponents/infoButtonInTh.tsx
+++ b/app/components/timeGroup/timeGroupMore/subcomponents/infoButtonInTh.tsx
@@ -1,0 +1,25 @@
+import Tooltip from "@/app/components/subcomponents/tooltip"
+
+export interface I_TooltipProps {
+    isVisible : boolean,
+    message : string,
+    onClick : () => void,
+    close: () => void,
+}
+
+export default function InfoButtonInHeader({tooltipProps} : { tooltipProps : I_TooltipProps }){
+    return <>
+            <button 
+                onClick={ tooltipProps.onClick } 
+                className={"rounded-full w-4 h-4 bg-violet-500 hover:opacity-80 text-white text-xs font-semibold font-serif leading-none flex items-center justify-center"}
+                >
+                i
+            </button>
+            { tooltipProps.isVisible ?
+                <Tooltip close={ tooltipProps.close } posAndWidthCSS={"bottom-5 left-2 text-left w-64"}>
+                    { tooltipProps.message }
+                </Tooltip>
+                : null
+            }
+            </>
+}

--- a/app/components/timeGroup/timeGroupMore/subcomponents/productionSummary.tsx
+++ b/app/components/timeGroup/timeGroupMore/subcomponents/productionSummary.tsx
@@ -18,26 +18,17 @@ export default function ProductionSettingsSummary({productionSettings, levels, e
         <div className={"flex w-40" + " " + extraCSS}>
             {
                 Object.keys(productionSettings).map((myKey, idx) => {
-                    const notUnlocked = levels[myKey as keyof typeof levels] === 0;
 
+                    const notUnlocked = levels[myKey as keyof typeof levels] === 0;
                     let conditionalCSS = 
                         notUnlocked ?
                             isDuringOfflinePeriod ?
-                                "border-greyBlue-400 text-greyBlue-400"
+                                "border-greyBlue-300 text-greyBlue-400 bg-greyBlue-50"
                                 : "border-greyBlue-200 text-greyBlue-200"
                             :
                             resourceCSS[productionSettings[myKey as keyof typeof productionSettings] as keyof typeof resourceCSS].badge;
 
                     conditionalCSS = idx === 0 ? conditionalCSS + " " + "border-l" : conditionalCSS;
-
-                    let outerBorderConditionalCSS = 
-                        isDuringOfflinePeriod && idx === 0 ? 
-                            "border-t border-b border-l"
-                            : isDuringOfflinePeriod && idx === Object.keys(productionSettings).length - 1 ?
-                                "border-r border-t border-b"
-                                : isDuringOfflinePeriod ?
-                                    "border-t border-b"
-                                    : "";
 
                     return  <div key={idx} className={"w-5 flex flex-col justify-center text-xs" }>
                                 { wantHeadings ?
@@ -47,8 +38,8 @@ export default function ProductionSettingsSummary({productionSettings, levels, e
                                     : null
                                 }
 
-                                <div className={"border-greyBlue-500" + " " + outerBorderConditionalCSS}>
-                                    <div className={"flex items-center justify-center border-t border-b border-r" + " " + conditionalCSS}>
+                                <div>
+                                    <div className={"flex items-center justify-center border-r border-t border-b" + " " + conditionalCSS}>
                                         {notUnlocked ? "-" : productionSettings[myKey as keyof typeof productionSettings].charAt(0).toLowerCase()}
                                     </div>
                                 </div>

--- a/app/components/timeGroup/timeGroupMore/subcomponents/sectionProductionSettings.tsx
+++ b/app/components/timeGroup/timeGroupMore/subcomponents/sectionProductionSettings.tsx
@@ -22,7 +22,7 @@ export default function ProductionSettingsSection({productionSettings, levels, i
 
     return (
         <section className={"py-1 flex flex-col gap-1"}>
-            <TimeGroupMoreSubheading text={"Settings"} />
+            <TimeGroupMoreSubheading text={"Current Settings"} />
             <ProductionSettingsSummary 
                 productionSettings={productionSettings} 
                 levels={levels} 

--- a/app/components/timeGroup/timeGroupMore/subcomponents/sideTableHeading.tsx
+++ b/app/components/timeGroup/timeGroupMore/subcomponents/sideTableHeading.tsx
@@ -1,0 +1,8 @@
+
+
+export default function SideHeading({ extraCSS, children } : { extraCSS? : string, children : React.ReactNode }){
+    extraCSS = extraCSS === undefined ? "" : " " + extraCSS;
+    return  <th className={"font-medium px-1 bg-violet-200 text-black border border-violet-400" + extraCSS}>
+                { children }
+            </th>
+}

--- a/app/components/timeGroup/timeGroupMore/timeGroupMore.tsx
+++ b/app/components/timeGroup/timeGroupMore/timeGroupMore.tsx
@@ -19,36 +19,34 @@ export default function TimeGroupMore({ data, remainingTimeGroups, gameState, bo
     : I_TimeGroupMore )
     : JSX.Element {
 
-    const moreData = calcTimeGroupMoreData(data, remainingTimeGroups);
+    const moreData = calcTimeGroupMoreData(data, remainingTimeGroups, gameState);
     const leftHeadingWidth = "w-20";
 
     const offlineModeCSS = isDuringOfflinePeriod ?
-                            "bg-greyBlue-700 text-white"
+                            "bg-greyBlue-100 text-black"
                             : "bg-white";
     const offlineModeHr = isDuringOfflinePeriod ?
                             ""
                             : "border-b border-gray-200 mt-2";
 
     return (
-        <section className={"flex flex-col gap-2 border-l border-r px-2 pb-4" + " " + borderColour + " " + offlineModeCSS}>
-            <div className={"mb-1" + " " + offlineModeHr}></div>
-            <DustStatsSection 
-                moreData={moreData} 
-                gameState={gameState} 
-                leftHeadingWidth={leftHeadingWidth} 
-                isDuringOfflinePeriod={isDuringOfflinePeriod} 
-            />
+        <section className={"flex flex-col gap-5 border-l border-r px-2 pb-4" + " " + borderColour + " " + offlineModeCSS}>
+            <div className={"-mb-2" + " " + offlineModeHr}></div>
             <ProductionSettingsSection 
                 productionSettings={ data.productionSettingsDuring } 
                 levels={ data.levelsAtEnd } 
                 leftHeadingWidth={leftHeadingWidth} 
                 isDuringOfflinePeriod={isDuringOfflinePeriod} 
             />
+            <DustStatsSection 
+                moreData={moreData} 
+                gameState={gameState} 
+                leftHeadingWidth={leftHeadingWidth} 
+            />
             <ProductionTableSection 
                 moreData={moreData} 
                 gameState={gameState} 
                 leftHeadingWidth={leftHeadingWidth} 
-                isDuringOfflinePeriod={isDuringOfflinePeriod}
             />
         </section>
     )

--- a/app/components/timeGroup/timeGroupMore/utils/types.tsx
+++ b/app/components/timeGroup/timeGroupMore/utils/types.tsx
@@ -11,14 +11,15 @@ export interface I_MoreSections {
 
 
 export type T_MoreData = {
-    stockpiles : T_ResourceColours,
-    rates : T_ResourceColours,
-    spendRemaining : T_ResourceColours,
-    totalAtRates : T_ResourceColours,
-    doneAt : T_ResourceColours,
+    eggStockpiles : T_ResourceColours,
+    eggRates : T_ResourceColours,
+    eggsSpendRemaining : T_ResourceColours,
+    eggsTotalAtEnd : T_ResourceColours,
+    eggsDoneAt : T_ResourceColours,
     dustNow : number,
-    allToDust : T_AllToDustOutput,
-    finishAt : number,
+    dustRates: number[],
+    dustFinishTimes: number[],
+    dustTotals: number[],
 }
 
 

--- a/app/components/timeGroup/timeGroupMore/utils/useAtEndInfoTooltip.tsx
+++ b/app/components/timeGroup/timeGroupMore/utils/useAtEndInfoTooltip.tsx
@@ -1,0 +1,13 @@
+import { useState, MutableRefObject } from "react";
+
+export function useAtEndInfoTooltip(adBoost : MutableRefObject<boolean | undefined>){
+  
+    const [atEndTooltipIsVisible, setAtEndTooltipIsVisible] = useState(false);
+
+    return {
+        isVisible: atEndTooltipIsVisible,
+        message: `Assuming ad boost remains ${adBoost.current ? "active" : "inactive"} and no further upgrades are purchased`,
+        onClick: () => setAtEndTooltipIsVisible(prev => !prev),
+        close: () => { setAtEndTooltipIsVisible(false) },
+    }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -86,7 +86,7 @@ export default function Home() {
 
 
 function MainPageHeading(){
-  return  <h1 className={"[height:4.5rem] flex flex-col px-3 pt-1 pb-3 block bg-white md:sticky md:top-0 md:relative md:[grid-area:heading]"}>
+  return  <h1 className={"[height:4.5rem] relative z-10 flex flex-col px-3 pt-1 pb-3 block bg-white md:sticky md:top-0 md:relative md:[grid-area:heading]"}>
             <span className={"text-3xl font-extrabold block leading-snug text-violet-700"}>Event&nbsp;Planner</span>
             <span className={"text-sm block leading-none"}>Idle&nbsp;Apocalypse: Lost&nbsp;in&nbsp;Time&nbsp;</span>
           </h1>

--- a/app/utils/calcResults.tsx
+++ b/app/utils/calcResults.tsx
@@ -4,6 +4,7 @@ import { calcStockpilesAdvancedByTime } from './calcStockpilesAdvancedByTime';
 import { T_DATA_KEYS, getWorkerOutputsFromJSON } from "./getDataFromJSON";
 import { T_Levels, T_SuggestionData, T_ResultData, T_Action, T_PurchaseData, T_PremiumInfo, T_ProductionSettings, T_AllToDustOutput, T_GameState, T_TimeGroup, T_Stockpiles } from "./types";
 import { calcProductionSettings } from "./productionSettingsHelpers";
+import { defaultProductionSettings } from "./defaults";
 
 
 
@@ -22,12 +23,18 @@ export function calcDustAtEndWithMaxDustProduction({timeID, stockpiles, levels, 
     if(remainingTime < 0){
         return { value: 0, rate: 0 };
     }
-    const dustySettings : T_ProductionSettings = productionSettingsAllToDust(productionSettings);
-    const dustRate = calcProductionRate('dust', levels, premiumInfo, dustySettings);
+    
+    const dustRate = calcMaxDustRate(levels, premiumInfo, productionSettings);
     return {
         value: Math.round(remainingTime * dustRate + stockpiles.dust),
         rate: dustRate
     };
+}
+
+
+export function calcMaxDustRate(levels : T_Levels, premiumInfo : T_PremiumInfo, productionSettings : T_ProductionSettings = defaultProductionSettings){
+    const dustySettings : T_ProductionSettings = productionSettingsAllToDust(productionSettings);
+    return calcProductionRate('dust', levels, premiumInfo, dustySettings);
 }
 
 

--- a/app/utils/formatting.tsx
+++ b/app/utils/formatting.tsx
@@ -4,27 +4,27 @@ export const resourceCSS = {
     blue: {
         badge: "bg-sky-700 text-white border-sky-800",
         hover: "hover:bg-sky-600 hover:opacity-100",
-        cell : "bg-sky-50 border-sky-200",
+        cell : "bg-sky-50 border-sky-300",
     },
     green: {
         badge: "bg-green-700 text-white border-green-800",
         hover: "hover:bg-green-600 hover:opacity-100",
-        cell : "bg-green-50 border-green-200",
+        cell : "bg-green-50 border-green-300",
     },
     red: {
         badge: "bg-red-700 text-white border-red-800",
         hover: "hover:bg-red-600 hover:opacity-100",
-        cell : "bg-red-50 border-red-200",
+        cell : "bg-red-50 border-red-300",
     },
     yellow: {
         badge: "bg-amber-400 text-black font-bold border-amber-500",
         hover: "hover:bg-amber-300 hover:opacity-100",
-        cell : "bg-amber-50 border-amber-200",
+        cell : "bg-amber-50 border-amber-300",
     },
     dust: {
         badge: "bg-lime-300 text-black font-bold border-lime-500",
         hover: "hover:bg-lime-200 text-black hover:opacity-100",
-        cell : "bg-lime-50 border-lime-200",
+        cell : "bg-lime-50 border-lime-400 text-black",
     },
 
 }


### PR DESCRIPTION
* Values in the egg section now correctly take into account the upgrades which were purchased in the current timeGroup
* Dust section now displays a table showing rates, totals and 1st prize time for both current and maxDust production settings
* Added tooltip to explain conditions of "at end" figures
* Formatting adjustments to "more" section