### PR TITLE
Add "plan mode" for game state input

### DIFF
--- a/app/components/forms/gameState/subcomponents/changeModeButton.tsx
+++ b/app/components/forms/gameState/subcomponents/changeModeButton.tsx
@@ -1,0 +1,16 @@
+export interface I_ChangeModeButton {
+    changeMode: () => void
+}
+
+export default function ChangeModeButton({ changeMode } 
+    : I_ChangeModeButton) 
+    : JSX.Element {
+
+    return  <button
+                type={"button"}
+                onClick={changeMode}
+                className={"absolute [top:calc(2.75rem+1px)] right-5 text-xs hover:bg-violet-100 w-max px-1 pb-0.5 text-violet-500 rounded-b"}
+                >
+                change mode
+            </button>
+}

--- a/app/components/forms/gameState/subcomponents/fieldAdBoost.tsx
+++ b/app/components/forms/gameState/subcomponents/fieldAdBoost.tsx
@@ -1,0 +1,22 @@
+import Checkbox from "../../subcomponents/checkbox"
+
+export interface I_AdBoostInputEle {
+    hasAdBoost : boolean, 
+    toggleAdBoost : () => void,
+}
+export default function AdBoost({hasAdBoost, toggleAdBoost}
+    : I_AdBoostInputEle)
+    : JSX.Element {
+
+    return  <div className={"flex gap-2"}>
+                <Checkbox 
+                    checked={hasAdBoost} 
+                    onChange={ toggleAdBoost } 
+                    disabled={false}
+                    idStr={"id_adBoost"}
+                    name={"adBoost"}
+                    displayText={"Ad Boost"}
+                    value={"adBoost"}
+                />
+            </div>
+}

--- a/app/components/forms/gameState/subcomponents/fieldAllEggs.tsx
+++ b/app/components/forms/gameState/subcomponents/fieldAllEggs.tsx
@@ -1,0 +1,30 @@
+/*
+    "All Eggs" label and input, for use in both Active and Plan mode forms
+*/
+
+import { T_GameState } from "@/app/utils/types";
+
+import Select from '../../subcomponents/select';
+
+import { Label, getUpgradeOptions, formatValueStr } from "../gameState";
+
+
+export interface I_AllEggs {
+    gameState : T_GameState, 
+    handleLevelChange : (e : React.ChangeEvent<HTMLSelectElement>) => void,
+}
+export default function AllEggs({gameState, handleLevelChange} 
+    : I_AllEggs) 
+    : JSX.Element {
+
+    return  <div className={"flex gap-2"}>
+                <Label htmlFor={"id_AllEggs"}>All Eggs</Label>
+                <Select 
+                    selectExtraCSS={undefined} 
+                    id={"id_AllEggs"} 
+                    initValue={gameState === null ? undefined : formatValueStr("All", gameState.premiumInfo.allEggs)} 
+                    options={getUpgradeOptions({ name: "All", max: 5 })} 
+                    handleChange={handleLevelChange} 
+                />
+            </div>
+}

--- a/app/components/forms/gameState/subcomponents/formActiveMode.tsx
+++ b/app/components/forms/gameState/subcomponents/formActiveMode.tsx
@@ -1,0 +1,121 @@
+/*
+    UI form for "active mode"
+    Active mode is for when the event is running and the user wishes to enter their current progress
+    then see a projected outcome and, possibly, adjust their plan going forwards
+*/
+
+import { useState } from "react";
+
+import { ModalMultiPageNav, ModalSubmitButton } from "../../../subcomponents/modal";
+
+import { useActiveGameStatusForm } from "../utils/useActiveGameStatusForm";
+
+import { InputPageWrapper, I_StatusFormSharedProps } from "../gameState";
+
+import InputGeneral from './pageGeneral';
+import InputStockpiles from './pageStockpiles';
+import InputLevelsWorkers from './pageLevelsWorkers';
+import InputLevelsOther from './pageLevelsOther';
+import { I_ChangeModeButton } from "./changeModeButton";
+
+
+interface I_ActiveModeForm extends I_StatusFormSharedProps, I_ChangeModeButton {
+    wantBackToMode : boolean, 
+}
+export default function FormActiveMode({gameState, setGameState, changeMode, wantBackToMode, closeModal}
+    : I_ActiveModeForm)
+    : JSX.Element {
+
+    const { onSubmit,
+            levels,
+            handleLevelChange,
+            hasAdBoost,
+            toggleAdBoost,
+            timeEntered,
+            setTimeEntered,
+            timeRemaining,
+            setTimeRemaining,
+            controlledStockpileValue,
+            updateStockpiles,
+            setStateOnChange,
+        } = useActiveGameStatusForm({setGameState, gameState, closeModal});
+
+
+    const [activePage, setActivePage] = useState<number>(1);
+    const MAX_PAGE_NUM = 4;
+
+    function changePage(targetPage : number){
+        if(targetPage === 0 && wantBackToMode){
+            changeMode();
+        }
+        else if(targetPage > 0 && targetPage <= MAX_PAGE_NUM){
+            setActivePage(targetPage);
+        }
+    }
+
+    function wantDisableBack(targetPage : number){
+        return targetPage === 0 && !wantBackToMode;
+    }
+
+    return <form onSubmit={(e) => onSubmit(e)}>
+                <InputPageWrapper 
+                    isVisible={ activePage === 1 }
+                    >
+                    <InputGeneral
+                        timeEntered={timeEntered}
+                        setStateOnChange={setStateOnChange}
+                        setTimeEntered={setTimeEntered}
+                        timeRemaining={timeRemaining}
+                        setTimeRemaining={setTimeRemaining}
+                        gameState={gameState}
+                        handleLevelChange={handleLevelChange}
+                        hasAdBoost={hasAdBoost}
+                        toggleAdBoost={toggleAdBoost}
+                    />
+                </InputPageWrapper>
+
+                <InputPageWrapper 
+                    isVisible={ activePage === 2 } 
+                    heading={`Current Stockpiles`}  
+                    >
+                    <InputStockpiles
+                        controlledStockpileValue={controlledStockpileValue}
+                        updateStockpiles={updateStockpiles}
+                    />
+                </InputPageWrapper>
+
+                <InputPageWrapper 
+                    isVisible={ activePage === 3 } 
+                    heading={`Worker Levels`}  
+                    >
+                    <InputLevelsWorkers
+                        handleLevelChange={handleLevelChange} 
+                        gameState={gameState} 
+                        levels={levels}
+                    />
+                </InputPageWrapper>
+
+                <InputPageWrapper 
+                    isVisible={ activePage === MAX_PAGE_NUM }  
+                    >
+                    <InputLevelsOther
+                        handleLevelChange={handleLevelChange} 
+                        gameState={gameState} 
+                        levels={levels}
+                    />
+                </InputPageWrapper>
+
+                <ModalMultiPageNav 
+                    activePage={activePage} 
+                    changePage={changePage} 
+                    numPages={MAX_PAGE_NUM} 
+                    submitLabel={"enter"}
+                    wantDisableBack={wantDisableBack}
+                />
+                <ModalSubmitButton 
+                    label={"submit"} 
+                    extraCSS={'sr-only [padding:0] [height:0]'} 
+                    disabled={false}
+                />
+            </form>
+}

--- a/app/components/forms/gameState/subcomponents/formPlanMode.tsx
+++ b/app/components/forms/gameState/subcomponents/formPlanMode.tsx
@@ -1,0 +1,82 @@
+/*
+    UI form for "plan mode"
+    No need for "progress" inputs in this case, so we can show the user a more simplified form.
+    Add ability to try different start times
+
+*/
+
+import AllEggs from "./fieldAllEggs";
+import AdBoost from "./fieldAdBoost";
+
+import { InputPageWrapper } from "../gameState"
+import { SelectHours, SelectMinutes } from '../../subcomponents/select';
+import { ModalSubmitButton } from "@/app/components/subcomponents/modal";
+import { usePlanGameStatusForm } from "../utils/usePlanGameStatusForm";
+import { deepCopy } from "@/app/utils/consts";
+import { Label, I_StatusFormSharedProps } from "../gameState";
+
+export default function FormPlanMode({gameState, setGameState, closeModal, isInitialisingMode } 
+    : I_StatusFormSharedProps & { isInitialisingMode : boolean })
+    : JSX.Element {
+
+    const {
+        onSubmit,
+        setAllEggs,
+        hasAdBoost,
+        toggleAdBoost,
+        startTime,
+        setStartTime,
+    } = usePlanGameStatusForm({gameState, setGameState, closeModal});
+
+
+    return  <form onSubmit={(e) => onSubmit(e)}>
+                <InputPageWrapper isVisible={true}>
+                    <div className={`flex flex-col gap-6 ${isInitialisingMode ? "mt-3" : "mt-5"}`}>
+                        <StartTime 
+                            startTime={startTime} 
+                            setStartTime={setStartTime} 
+                        />
+                        <AllEggs gameState={gameState} handleLevelChange={setAllEggs} />
+                        <AdBoost hasAdBoost={hasAdBoost} toggleAdBoost={toggleAdBoost} />
+                    </div>
+                </InputPageWrapper>
+                <ModalSubmitButton 
+                    label={"submit"} 
+                    disabled={false}
+                />
+            </form>
+}
+
+
+function StartTime({ startTime, setStartTime } : any) : JSX.Element {
+
+    function handleHourChange(e : React.ChangeEvent<HTMLSelectElement>){
+        let newTime = deepCopy(startTime);
+        newTime.setHours(parseInt(e.target.value));
+        setStartTime(newTime);
+    }
+
+    function handleMinuteChange(e : React.ChangeEvent<HTMLSelectElement>){
+        let newTime = structuredClone(startTime);
+        newTime.setMinutes(parseInt(e.target.value));
+        setStartTime(newTime);
+    }
+
+    return  <fieldset className={"flex items-center"}>
+                <span><Label htmlFor={""} tagName="legend">Starting At</Label></span>
+                <div className={"flex items-center"}>
+                    <SelectHours
+                        id={"id_planStartHour"}
+                        initValue={startTime.getHours().toString()}
+                        handleChange={handleHourChange}
+                    />
+                    <SelectMinutes
+                        id={"id_planStartMinute"}
+                        initValue={startTime.getMinutes().toString()}
+                        handleChange={handleMinuteChange}
+                    />
+                </div>
+            </fieldset>
+}
+
+

--- a/app/components/forms/gameState/subcomponents/formSetMode.tsx
+++ b/app/components/forms/gameState/subcomponents/formSetMode.tsx
@@ -1,0 +1,118 @@
+import { useState } from "react";
+
+import { InputPageWrapper } from "../gameState";
+
+import Radio from '../../subcomponents/radio';
+import { PlanMode, T_PlanModeKit } from "@/app/utils/usePlanMode";
+import { Button } from "../../subcomponents/buttons";
+
+
+interface I_ModeSetter extends T_PlanModeKit{
+    close : () => void,
+}
+
+export default function FormSetMode({ isActive, isPlan, setMode, close } 
+    : I_ModeSetter) 
+    : JSX.Element {
+
+    const [controlled, setControlled] = useState<PlanMode | null>(null);
+
+    function onSubmit(e : React.SyntheticEvent){
+        e.preventDefault();
+        if(controlled !== null){
+            setMode(controlled);
+        }
+        close();
+    }
+
+    const planIsSelected = controlled === null && isPlan || controlled === PlanMode.plan;
+    const activeIsSelected = controlled === null && isActive || controlled === PlanMode.active;
+    return  <form onSubmit={(e) => onSubmit(e)}>
+                <InputPageWrapper isVisible={true}>
+                    <fieldset className={"flex flex-col gap-6"}>
+                        <legend className={"flex flex-col mb-5"}>
+                            <span className={"font-bold text-base"}>Select input mode</span>
+                            <span className={"font-medium text-sm text-neutral-600"}>(you can change this later)</span>
+                        </legend>
+
+                        <Radio 
+                            checked={ planIsSelected }
+                            disabled={ false }
+                            handleSelection={ () => setControlled(PlanMode.plan) }
+                            value={"planMode"}
+                            >
+                                <OptionBox 
+                                    title={"Plan"}
+                                    description={"Work out a plan in advance"}
+                                    bullets={[
+                                        "Try different start times",
+                                        "Skip inputting in-progress details",
+                                    ]}
+                                    isSelected={ planIsSelected } 
+                                />
+                        </Radio>
+                        <Radio 
+                            checked={ activeIsSelected }
+                            disabled={ false }
+                            handleSelection={ () => setControlled(PlanMode.active) }
+                            value={"activeMode"}
+                            >
+                                <OptionBox 
+                                    title={"Active"}
+                                    description={"Event is running now: view and adjust your plan as you go"}
+                                    bullets={[
+                                        "Skip inputting start time",
+                                        "Update time remaining, stockpiles and levels as necessary",
+                                    ]}
+                                    isSelected={ activeIsSelected } 
+                                />
+                        </Radio>
+                    </fieldset>
+                </InputPageWrapper>
+            
+                <Button
+                    key={"mode_set"}
+                    size={"default"}
+                    colours={"primary"}
+                    htmlType={"submit"}
+                    disabled={ !isActive && !isPlan && controlled === null }
+                    >
+                    next&nbsp;&raquo;
+                </Button>
+            </form>
+}
+
+
+function OptionBox({title, description, bullets, isSelected} : any){
+
+    const [hover, setHover] = useState(false);
+
+    const wrapperSelectedCSS = isSelected ? 
+        "border-violet-500 bg-violet-100"
+        : "border-gray-300 hover:bg-violet-50 hover:border-violet-300";
+    const hrSelectedCSS = isSelected ?
+        "border-violet-400"
+        : hover ?
+            "border-violet-300"
+            : "border-gray-300";
+
+    return  <div className={`ease-linear duration-75 border-2 rounded px-4 pt-3 pb-5 ${wrapperSelectedCSS} hover:border-violet-`}
+                onMouseEnter={() => setHover(true) }
+                onMouseLeave={() => setHover(false)}
+                >
+                <h4 className={"font-semibold text-base"}>{title}</h4>
+                <p className={"mt-2 text-sm"}>{description}</p>
+                <hr className={`ease-linear duration-75 my-4 border-t ${hrSelectedCSS}`}></hr>
+                <ul className={"list-disc ml-5 text-xs"}>
+                    { bullets.map((ele : string, idx : number) => {
+                        return  <li key={`${idx}_${ele.substring(0,3)}_${ele.substring(-3)}`}
+                                    className={"mt-1"}
+                                    >
+                                    {ele}
+                                </li>
+                    })
+
+                    }
+                </ul>
+            </div>
+}

--- a/app/components/forms/gameState/subcomponents/pageGeneral.tsx
+++ b/app/components/forms/gameState/subcomponents/pageGeneral.tsx
@@ -1,23 +1,25 @@
 import { useState, Dispatch, SetStateAction } from "react";
 
 import { MAX_DAYS } from '../../../../utils/consts';
-import { getDateDisplayStr } from '../../../../utils/dateAndTimeHelpers';
+import { calcDateDisplayStr } from '../../../../utils/dateAndTimeHelpers';
 import { capitalise } from '../../../../utils/formatting';
-import { T_GameState, T_TimeRemainingDHM } from "../../../../utils/types";
+import { T_TimeRemainingDHM } from "../../../../utils/types";
 
-import Select from '../../subcomponents/select';
 import { Button } from '../../subcomponents/buttons';
-import { formatValueStr, getUpgradeOptions, InputNumberAsText, Label } from "../gameState"
 import FieldsetWrapper from "../../subcomponents/fieldsetWrapper";
-import Checkbox from "../../subcomponents/checkbox";
+
+import { InputNumberAsText, Label } from "../gameState"
+
+import AllEggs, { I_AllEggs } from "./fieldAllEggs";
+import AdBoost, { I_AdBoostInputEle } from "./fieldAdBoost";
 
 
-export interface I_InputGeneral extends I_TimeRemainingFieldset, I_Entered, I_AllEggs, I_AdBoost {}
+export interface I_InputGeneral extends I_TimeRemainingFieldset, I_Entered, I_AllEggs, I_AdBoostInputEle {}
 export default function InputGeneral({timeRemaining, setTimeRemaining, timeEntered, setStateOnChange, setTimeEntered, gameState, handleLevelChange, hasAdBoost, toggleAdBoost } 
     : I_InputGeneral)
     : JSX.Element {
 
-    return  <div className={"flex flex-col gap-6 mt-1"}>
+    return  <div className={"flex flex-col gap-6 mt-2"}>
                 <TimeRemainingFieldset timeRemaining={timeRemaining} setTimeRemaining={setTimeRemaining} />
                 <Entered timeEntered={timeEntered} setStateOnChange={setStateOnChange} setTimeEntered={setTimeEntered} />
                 <AllEggs gameState={gameState} handleLevelChange={handleLevelChange} />
@@ -27,50 +29,8 @@ export default function InputGeneral({timeRemaining, setTimeRemaining, timeEnter
 }
 
 
-interface I_AllEggs {
-    gameState : T_GameState, 
-    handleLevelChange : (e : React.ChangeEvent<HTMLSelectElement>) => void,
-}
-function AllEggs({gameState, handleLevelChange} 
-    : I_AllEggs) 
-    : JSX.Element {
-
-    return  <div className={"flex gap-2"}>
-                <Label htmlFor={"id_AllEggs"}>All Eggs</Label>
-                <Select 
-                    selectExtraCSS={undefined} 
-                    id={"id_AllEggs"} 
-                    initValue={gameState === null ? undefined : formatValueStr("All", gameState.premiumInfo.allEggs)} 
-                    options={getUpgradeOptions({ name: "All", max: 5 })} handleChange={handleLevelChange} 
-                    />
-            </div>
-}
-
-
-interface I_AdBoost {
-    hasAdBoost : boolean, 
-    toggleAdBoost : () => void,
-}
-function AdBoost({hasAdBoost, toggleAdBoost}
-    : I_AdBoost)
-    : JSX.Element {
-
-    return  <div className={"flex gap-2"}>
-                <Checkbox 
-                    checked={hasAdBoost} 
-                    onChange={ toggleAdBoost } 
-                    disabled={false}
-                    idStr={"id_adBoost"}
-                    name={"adBoost"}
-                    displayText={"Ad Boost"}
-                    value={"adBoost"}
-                />
-            </div>
-}
-
-
 interface I_Entered {
-    timeEntered : Date | null, 
+    timeEntered : Date, 
     setStateOnChange : (e : React.ChangeEvent<any>, setFunction : Dispatch<SetStateAction<any>>) => void, 
     setTimeEntered : Dispatch<SetStateAction<Date>>
 }
@@ -98,13 +58,13 @@ function Entered({timeEntered, setStateOnChange, setTimeEntered}
                 suppressHydrationWarning={true} 
                 className={"ml-2"}
                 >
-                { getDateDisplayStr(timeEntered) }
+                { calcDateDisplayStr(timeEntered) }
             </p>
             <input 
                 hidden 
                 type="datetime-local" 
                 id={"id_timeEntered"} 
-                value={timeEntered == null ? "" : `${timeEntered}`} 
+                value={`${timeEntered}`} 
                 onChange={(e) => setStateOnChange(e, setTimeEntered)}
             />
         </div>

--- a/app/components/forms/gameState/utils/calcLevelKeyValue.tsx
+++ b/app/components/forms/gameState/utils/calcLevelKeyValue.tsx
@@ -1,0 +1,12 @@
+export function calcLevelKeyValue(e : React.ChangeEvent<HTMLSelectElement>){
+    const valueStr = e.target.value;
+    const splitStr = valueStr.split("_");
+    let key = splitStr[0];
+    key = key.toLowerCase();
+    const prodInt = parseInt(splitStr[1]);  
+
+    return {
+        key: key,
+        value : prodInt
+    }
+}

--- a/app/components/forms/gameState/utils/useActiveGameStatusForm.tsx
+++ b/app/components/forms/gameState/utils/useActiveGameStatusForm.tsx
@@ -1,0 +1,162 @@
+import { useState, SetStateAction } from "react";
+
+import { deepCopy, MS_PER_MINUTE } from "@/app/utils/consts";
+import { startingLevels, startingStockpiles, startingTimeRemaining, lateGameSettings, maxLevels } from '@/app/utils/defaults';
+import { convertTimeIDToDHM, convertTimeRemainingToMinutes } from "@/app/utils/dateAndTimeHelpers";
+import { T_GameState, T_TimeRemainingDHM, T_Stockpiles, T_Levels } from "@/app/utils/types";
+
+import { I_InputGeneral } from '../subcomponents/pageGeneral';
+import { I_InputStockpiles } from '../subcomponents/pageStockpiles';
+import { I_InputLevelsOther } from '../subcomponents/pageLevelsOther';
+
+import { I_StatusFormSharedProps } from "../gameState";
+
+import { useAdBoost } from "./useAdBoost";
+import { calcLevelKeyValue } from "./calcLevelKeyValue";
+import { I_AdBoostInputEle } from "../subcomponents/fieldAdBoost";
+
+type T_OutputUseGameStatusForm = 
+    Pick<I_InputGeneral, 
+        "handleLevelChange" | 
+        "setStateOnChange" | 
+        "setTimeEntered" | 
+        "setTimeRemaining" | 
+        "timeEntered" | 
+        "timeRemaining"> &
+    Pick<I_InputLevelsOther, 
+        "levels" | 
+        "handleLevelChange"> &
+    I_AdBoostInputEle &
+    I_InputStockpiles & {
+    onSubmit : (e : React.SyntheticEvent) => void,
+}
+export function useActiveGameStatusForm({gameState, setGameState, closeModal}
+    : I_StatusFormSharedProps)
+    : T_OutputUseGameStatusForm {
+
+    const [timeEntered, setTimeEntered] = useState<Date>(new Date());
+    const [timeRemaining, setTimeRemaining] = useState<T_TimeRemainingDHM>(gameState === null ? startingTimeRemaining : convertTimeIDToDHM(gameState.timeRemaining))
+    const [allEggsLevel, setAllEggsLevel] = useState<number>(gameState === null ? 0 : gameState.premiumInfo.allEggs)
+    const [stockpiles, setStockpiles] = useState<T_Stockpiles>(gameState === null ? deepCopy(startingStockpiles) : gameState.stockpiles)
+    const [levels, setLevels] = useState<T_Levels>(gameState === null ? deepCopy(startingLevels) : gameState.levels)
+
+    const {hasAdBoost, toggleAdBoost} = useAdBoost({gameState});
+
+
+    function setStateOnChange(e : React.ChangeEvent<any>, setFunction : React.Dispatch<SetStateAction<any>>){
+        setFunction(e.target.value);
+    }
+
+    // function setToLateGame(){
+    //     setTimeEntered(new Date(new Date().getTime() - 5 * 60 * 1000));
+    //     setTimeRemaining(lateGameSettings.timeRemainingDHM);
+    //     setHasAdBoost(lateGameSettings.hasAdBoost);
+    //     setAllEggsLevel(lateGameSettings.allEggs);
+    //     setStockpiles(lateGameSettings.stockpiles);
+    //     setLevels(lateGameSettings.levels);
+    // }
+
+    // function testLevelsDone(){
+    //     setTimeEntered(new Date(new Date().getTime() - 5 * 60 * 1000));
+    //     setTimeRemaining(lateGameSettings.timeRemainingDHM);
+    //     setHasAdBoost(lateGameSettings.hasAdBoost);
+    //     setAllEggsLevel(lateGameSettings.allEggs);
+    //     setStockpiles(lateGameSettings.stockpiles);
+    //     setLevels(maxLevels);
+    // }
+
+    function updateStockpiles(e : React.ChangeEvent<HTMLInputElement>, key : string){
+        let newStockpiles : T_Stockpiles = deepCopy(stockpiles);
+        newStockpiles[key as keyof T_Stockpiles] = parseInt(e.target.value);
+        setStockpiles(newStockpiles);
+    }
+
+    function handleLevelChange(e : React.ChangeEvent<HTMLSelectElement>){
+        const {key, value} = calcLevelKeyValue(e);
+
+        if(key === "all"){
+            setAllEggsLevel(value);
+            return;
+        }
+
+        let newLevels : T_Levels = deepCopy(levels);
+        if(key in newLevels){
+            newLevels[key as keyof typeof newLevels] = value;
+        }
+
+        setLevels(newLevels);
+    }
+    
+
+    function controlledStockpileValue(key : string){
+        if(!(key in stockpiles)){
+            return '';
+        }
+        let thisValue = stockpiles[key as keyof typeof stockpiles];
+        return thisValue === null ? '' : thisValue;
+    }
+
+
+    function onSubmit(e : React.SyntheticEvent){
+        e.preventDefault();
+        let newGameState = convertFormInputsToGameState();
+        
+        console.log("active hook new game state", newGameState);
+        setGameState(newGameState);
+        closeModal();
+    }
+
+
+    function convertFormInputsToGameState()
+        : T_GameState {
+    
+        const timeRemainingAsNum : number = convertTimeRemainingToMinutes(timeRemaining);
+        const startTime : Date = calcStartTime({timeEntered, timeRemaining: timeRemainingAsNum});
+    
+        function calcStartTime({ timeEntered, timeRemaining }
+            : Pick<T_GameState, "timeRemaining" | "timeEntered"> ) 
+            : Date {
+                
+            let startedAt : Date;
+            const TIME_REMAINING_AT_START = 3 * 24 * 60;
+        
+            if(timeRemaining === TIME_REMAINING_AT_START){
+                startedAt = timeEntered;
+            }
+            else{
+                let timePassed = (TIME_REMAINING_AT_START - timeRemaining) * MS_PER_MINUTE;
+                startedAt = new Date(timeEntered.getTime() - timePassed);
+            }
+            return startedAt;
+        }
+
+        return {
+            startTime,
+            timeEntered,
+            timeRemaining: timeRemainingAsNum,
+            premiumInfo: {
+                adBoost: hasAdBoost,
+                allEggs: allEggsLevel,
+            },
+            stockpiles,
+            levels,
+        }
+    }
+    
+
+    return {
+        onSubmit,
+        hasAdBoost,
+        toggleAdBoost,
+        timeEntered,
+        setStateOnChange,
+        setTimeEntered,
+        timeRemaining,
+        setTimeRemaining,
+        levels,
+        handleLevelChange,
+        controlledStockpileValue,
+        updateStockpiles
+    }
+}
+

--- a/app/components/forms/gameState/utils/useAdBoost.tsx
+++ b/app/components/forms/gameState/utils/useAdBoost.tsx
@@ -1,0 +1,20 @@
+import { T_GameState } from "@/app/utils/types";
+import { useState } from "react"
+
+import { I_AdBoostInputEle } from "../subcomponents/fieldAdBoost";
+
+export function useAdBoost({gameState}
+    : { gameState : T_GameState })
+    : I_AdBoostInputEle {
+
+    const [hasAdBoost, setHasAdBoost] = useState<boolean>(gameState.premiumInfo.adBoost);
+
+    function toggleAdBoost(){
+        setHasAdBoost(prevState => !prevState);
+    }
+
+    return {
+        hasAdBoost,
+        toggleAdBoost,
+    }
+}

--- a/app/components/forms/gameState/utils/usePlanGameStatusForm.tsx
+++ b/app/components/forms/gameState/utils/usePlanGameStatusForm.tsx
@@ -1,0 +1,69 @@
+import { useState, Dispatch, SetStateAction } from "react";
+
+import { deepCopy } from "@/app/utils/consts";
+import { convertTimeRemainingToMinutes } from "@/app/utils/dateAndTimeHelpers";
+import { startingLevels, startingStockpiles, startingTimeRemaining } from '@/app/utils/defaults';
+import { T_GameState } from "@/app/utils/types";
+
+import { I_StatusFormSharedProps } from "../gameState";
+
+import { calcLevelKeyValue } from "./calcLevelKeyValue";
+import { useAdBoost, T_OutputUseAdBoost } from "./useAdBoost";
+
+
+type T_OutputUsePlanGameStatusForm = 
+    T_OutputUseAdBoost & {
+    onSubmit : (e : React.SyntheticEvent) => void,
+    setAllEggs : (e : React.ChangeEvent<HTMLSelectElement>) => void,
+    startTime : Date,
+    setStartTime : Dispatch<SetStateAction<Date>>,
+}
+export function usePlanGameStatusForm({gameState, setGameState, closeModal}
+    : I_StatusFormSharedProps)
+    : T_OutputUsePlanGameStatusForm {
+
+    const [startTime, setStartTime] = useState<Date>(deepCopy(gameState.startTime));
+    const [allEggsLevel, setAllEggsLevel] = useState<number>(gameState.premiumInfo.allEggs);
+
+    const {hasAdBoost, toggleAdBoost} = useAdBoost({gameState});
+
+    function setAllEggs(e : React.ChangeEvent<HTMLSelectElement>){
+        const { value } = calcLevelKeyValue(e);
+        setAllEggsLevel(value);
+    }
+    
+    function onSubmit(e : React.SyntheticEvent){
+        e.preventDefault();
+        let newGameState = convertFormInputsToGameState();
+        setGameState(newGameState);
+        closeModal();
+    }
+
+    function convertFormInputsToGameState()
+        : T_GameState {
+    
+        const timeRemaining : number = convertTimeRemainingToMinutes(startingTimeRemaining);
+        return {
+            startTime,
+            timeEntered : new Date(),
+            timeRemaining,
+            premiumInfo: {
+                adBoost: hasAdBoost,
+                allEggs: allEggsLevel,
+            },
+            stockpiles : startingStockpiles,
+            levels : startingLevels,
+        }
+    }
+    
+    
+    return {
+        onSubmit,
+        setAllEggs,
+        hasAdBoost,
+        toggleAdBoost,
+        startTime,
+        setStartTime,
+    }
+}
+

--- a/app/components/forms/prodSettings.tsx
+++ b/app/components/forms/prodSettings.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
 import { deepCopy } from "../../utils/consts";
-import { defaultProductionSettings } from '../../utils/defaults';
+import { startingProductionSettings } from '../../utils/defaults';
 import { capitalise, resourceCSS } from '../../utils/formatting';
 import { T_DATA_KEYS, getWorkerOutputsFromJSON } from "../../utils/getDataFromJSON";
 import { T_Levels, T_ProductionSettings, T_SwitchAction } from '../../utils/types';
@@ -63,7 +63,7 @@ export default function ModalProdSettings({closeModal, initialProdSettings, curr
 function getInitSettingsForModal(currentProdSettings : T_ProductionSettings, currentSwitches : T_SwitchAction[])
     : T_ProductionSettings {
 
-    let result : T_ProductionSettings = deepCopy(defaultProductionSettings);
+    let result : T_ProductionSettings = deepCopy(startingProductionSettings);
     for(const [k, v] of Object.entries(currentProdSettings)){
         let idx = currentSwitches.findIndex(ele => ele.key === k);
         let newValue = v;

--- a/app/components/forms/subcomponents/checkbox.tsx
+++ b/app/components/forms/subcomponents/checkbox.tsx
@@ -25,7 +25,7 @@ export default function Checkbox({checked, disabled, onChange, idStr, name, disp
                 <span className={"block w-20 ml-2 text-black font-semibold"}>
                     { displayText }
                 </span>
-                <span className={`rounded w-5 h-5 flex items-center justify-center border ${checkedClasses}`}>
+                <span className={`ease-in duration-100 rounded w-5 h-5 flex items-center justify-center border ${checkedClasses}`}>
                     { checked ?
                         <IconCheck size={"16"} colour={"white"}/>
                         : null

--- a/app/components/forms/subcomponents/select.tsx
+++ b/app/components/forms/subcomponents/select.tsx
@@ -1,3 +1,6 @@
+import { ChangeEvent } from "react";
+import { calcOptionsForNumberRange } from "../utils/timeOptions";
+
 export interface I_SelectProps {
     id : string,
     options : T_OptionData[],
@@ -40,6 +43,59 @@ export function SelectWithLabel({id, labelExtraCSS, selectExtraCSS, labelDisplay
     )
 
 }
+
+
+interface I_SelectWithSRLabel extends I_SelectProps {
+    visualLabel: string,
+    srLabel : string,
+    extraCSS? : string,
+}
+export function SelectWithSRLabel({id, selectExtraCSS, options, handleChange, initValue, visualLabel, srLabel, extraCSS}
+    : I_SelectWithSRLabel)
+    : JSX.Element {
+
+    return <div>
+                <label htmlFor={id} className={"text-sm" + " " + extraCSS}>
+                    <span className={"sr-only"}>{srLabel}</span>
+                    <span aria-hidden={true}>{visualLabel}</span>
+                </label>
+                <Select id={id} selectExtraCSS={selectExtraCSS} options={options} handleChange={handleChange} initValue={initValue} />
+            </div>
+}
+
+
+export function SelectHours({id, handleChange, initValue}
+    : Pick<I_SelectProps, "id" | "handleChange" | "initValue">)
+    : JSX.Element {
+    return  <SelectWithSRLabel
+                id={id}
+                selectExtraCSS={undefined}
+                handleChange={(e : ChangeEvent<HTMLSelectElement>) => handleChange(e)}
+                initValue={initValue}
+                options={calcOptionsForNumberRange(0, 23)} 
+                visualLabel={""}
+                srLabel={"time: hour"}
+                extraCSS={"px-1"}
+            />
+}
+
+
+export function SelectMinutes({id, handleChange, initValue}
+    : Pick<I_SelectProps, "id" | "handleChange" | "initValue">)
+    : JSX.Element {
+    return  <SelectWithSRLabel
+                id={id}
+                selectExtraCSS={undefined}
+                handleChange={(e : ChangeEvent<HTMLSelectElement>) => handleChange(e)}
+                initValue={initValue}
+                options={calcOptionsForNumberRange(0, 59)} 
+                visualLabel={":"}
+                srLabel={"time: minute"}
+                extraCSS={"px-1"}
+            />
+}
+
+
 
 
 export type T_OptionData = {

--- a/app/components/forms/utils/timeOptions.tsx
+++ b/app/components/forms/utils/timeOptions.tsx
@@ -1,0 +1,74 @@
+import { ChangeEvent } from "react";
+
+import { T_GameState } from "@/app/utils/types";
+import { calcMonthName } from "@/app/utils/dateAndTimeHelpers";
+
+import { T_OptionData } from "../subcomponents/select";
+
+//calcOptionsForNumberRange : (firstNum : number, lastNum : number) => T_OptionData[]
+export function calcOptionsForNumberRange(firstNum : number, lastNum : number){
+    let options : T_OptionData[] = [];
+    for(let i = firstNum; i <= lastNum; i++){
+        let iStr = i.toString();
+        options.push({
+            valueStr: iStr,
+            displayStr: iStr.padStart(2, '0')
+        });
+    }
+    return options;
+}
+
+
+interface I_ValidDatesKit {
+    gameState : T_GameState,
+}
+
+type T_DateAndMonth = { date: number, month: number };
+type T_OutputOfflineTimesInputKit = {
+    selectedDateAsIndex : (e : ChangeEvent<HTMLSelectElement>) => number,
+    validDates : T_DateAndMonth[],
+    convertValidDatesToOptions : (dateObj : T_DateAndMonth[]) => T_OptionData[],
+}
+export function validDatesKit({ gameState }
+    : I_ValidDatesKit )
+    : T_OutputOfflineTimesInputKit {
+    const validDates = calcValidDates();
+
+    function selectedDateAsIndex(e : ChangeEvent<HTMLSelectElement>){
+        return validDates.findIndex(ele => ele.date === parseInt(e.target.value));
+    }
+
+    function calcValidDates(){
+        let endTime = new Date(gameState.startTime.getTime() + 3 * 24 * 60 * 60 * 1000);
+
+        let validDates : { date: number, month: number }[] = [];
+        let loopTime = new Date(gameState.startTime.getTime());
+        while(loopTime.getTime() <= endTime.getTime()){
+            validDates.push({
+                date: loopTime.getDate(), 
+                month: loopTime.getMonth()
+            });
+            loopTime.setDate(loopTime.getDate() + 1);
+        }
+
+        return validDates;
+    }
+
+    function convertValidDatesToOptions(validDates 
+        : { date : number, month : number }[])
+        : T_OptionData[]{
+
+        return validDates.map(ele => {
+            return {
+                valueStr: ele.date.toString(),
+                displayStr: `${ele.date} ${calcMonthName(ele.month)}`
+            }
+        });
+    }
+
+    return {
+        selectedDateAsIndex,
+        validDates,
+        convertValidDatesToOptions
+    }
+}

--- a/app/components/planner/planner.tsx
+++ b/app/components/planner/planner.tsx
@@ -1,7 +1,7 @@
 import { MutableRefObject, useRef } from 'react';
 
 import { MAX_TIME } from '../../utils/consts';
-import { defaultProductionSettings } from '../../utils/defaults';
+import { startingProductionSettings } from '../../utils/defaults';
 import { calcNewSwitchDisplay } from '../../utils/productionSettingsHelpers';
 import { T_ProductionSettings, T_PurchaseData, T_TimeGroup, T_Action, T_GameState, T_ProductionSettingsNow } from '../../utils/types';
 
@@ -40,7 +40,7 @@ export default function Planner({timeIDGroups, gameState, actions, setActions, p
                             prodSettingsNow !== null ?
                             prodSettingsNow.productionSettings
                                 : timeIDGroups.length === 0 ?
-                                    defaultProductionSettings
+                                    startingProductionSettings
                                     : timeIDGroups[0].productionSettingsDuring;
 
     const prodSettingsBeforeNowRef : MutableRefObject<T_ProductionSettings | undefined>  = useRef();

--- a/app/components/sectionGameState.tsx
+++ b/app/components/sectionGameState.tsx
@@ -1,4 +1,4 @@
-import { getDateDisplayStr, convertTimeIDToTimeRemaining } from '../utils/dateAndTimeHelpers';
+import { calcDateDisplayStr, convertTimeIDToTimeRemaining } from '../utils/dateAndTimeHelpers';
 import { maxedLevelCSS, capitalise, resourceCSS, toBillions, nbsp } from '../utils/formatting';
 import { T_GameState, T_Levels, T_Stockpiles } from '../utils/types';
 
@@ -44,8 +44,12 @@ function TimeAndPremiumStatus({gameState}
                     <div>{remTimeObj === null ? "" : `${remTimeObj.days}d ${remTimeObj.hours}h ${remTimeObj.minutes}m`}</div>
                 </GridRowWrapper>
 
+                <GridRowWrapper title={"Started"}>
+                    <div>{calcDateDisplayStr(gameState.startTime)}</div>
+                </GridRowWrapper>
+
                 <GridRowWrapper title={"Entered"}>
-                    <div suppressHydrationWarning={true}>{getDateDisplayStr(gameState.timeEntered)}</div>
+                    <div suppressHydrationWarning={true}>{calcDateDisplayStr(gameState.timeEntered)}</div>
                 </GridRowWrapper>
 
                 <GridRowWrapper title={`All${nbsp()}Eggs`}>
@@ -68,7 +72,7 @@ function TimeAndPremiumStatus({gameState}
 
 function GridRowWrapper({title, children} : { title : string, children : React.ReactNode }){
     return  <>
-                <div className={"col-start-1"}>{title}</div>
+                <div className={"col-start-1 font-medium"}>{title}</div>
                 {children}
             </>
 }

--- a/app/components/sectionOfflinePeriods.tsx
+++ b/app/components/sectionOfflinePeriods.tsx
@@ -1,4 +1,4 @@
-import { getDateDisplayStr, calcStartTime, printOfflineTime } from "../utils/dateAndTimeHelpers";
+import { calcDateDisplayStr, printOfflineTime } from "../utils/dateAndTimeHelpers";
 import { convertOfflineTimeToDate } from "../utils/offlinePeriodHelpers";
 import { T_GameState, T_OfflinePeriod } from "../utils/types";
 
@@ -40,8 +40,6 @@ function OfflineDisplay({offlinePeriods, gameState, openForm, idxEdit}
     : I_OfflineDisplay)
     : JSX.Element {
 
-    let startedAt = calcStartTime(gameState);
-
     return <div>
             { (offlinePeriods === undefined || offlinePeriods.length === 0) ?
                 <p>None entered</p>
@@ -52,15 +50,15 @@ function OfflineDisplay({offlinePeriods, gameState, openForm, idxEdit}
                         conditionalWrapperCSS = "text-gray-300";
                     }
 
-                    let startDate : Date = convertOfflineTimeToDate(ele.start, startedAt);
-                    let endDate : Date = convertOfflineTimeToDate(ele.end, startedAt);
+                    let startDate : Date = convertOfflineTimeToDate(ele.start, gameState.startTime);
+                    let endDate : Date = convertOfflineTimeToDate(ele.end, gameState.startTime);
 
                     return  <div key={`${printOfflineTime(ele.start)}_${printOfflineTime(ele.end)}`} className={"flex justify-between items-center mb-2" + " " + conditionalWrapperCSS}>
                                 <div className={"text-violet-800 font-bold"}>
                                     {idx + 1}
                                 </div>
                                 <div>
-                                    {getDateDisplayStr(startDate)} - {getDateDisplayStr(endDate)}
+                                    {calcDateDisplayStr(startDate)} - {calcDateDisplayStr(endDate)}
                                 </div>
 
                                 <Button

--- a/app/components/subcomponents/modal.tsx
+++ b/app/components/subcomponents/modal.tsx
@@ -106,22 +106,23 @@ export function ModalSubmitButton({label, extraCSS, disabled}
 interface I_ModalMultiPageNav {
     activePage : number, 
     numPages : number, 
-    changePage : Dispatch<SetStateAction<number>>,
-    submitLabel? : string
+    changePage : (pageNum : number) => void,
+    submitLabel? : string,
+    wantDisableBack : (pageNum : number) => boolean
 }
-export function ModalMultiPageNav({activePage, numPages, changePage, submitLabel}
+export function ModalMultiPageNav({activePage, numPages, changePage, submitLabel, wantDisableBack}
     : I_ModalMultiPageNav)
     : JSX.Element {
 
     return  <div aria-hidden={true} className={"flex flex-col justify-center gap-5"}>
-                <NavButtonBox activePage={activePage} numPages={numPages} changePage={changePage} submitLabel={submitLabel} />
+                <NavButtonBox activePage={activePage} numPages={numPages} changePage={changePage} submitLabel={submitLabel} wantDisableBack={wantDisableBack}/>
                 <ProgressStatus activePage={activePage} numPages={numPages} changePage={changePage} />
             </div>
 
 }
 
 
-function NavButtonBox({activePage, numPages, changePage, submitLabel}
+function NavButtonBox({activePage, numPages, changePage, submitLabel, wantDisableBack}
     : I_ModalMultiPageNav)
     : JSX.Element {
 
@@ -129,6 +130,15 @@ function NavButtonBox({activePage, numPages, changePage, submitLabel}
 
     return  <div className={"flex justify-center"}>
                 <div className={"flex justify-between w-full"}>
+                    <Button
+                        colours={'secondary'}
+                        htmlType={'button'}
+                        size={'twin'}
+                        onClick={() => changePage(activePage - 1)}
+                        disabled={wantDisableBack(activePage - 1)}
+                        >
+                        &laquo;&nbsp;back
+                    </Button>
                     {
                         isLastPage ?
                             <Button
@@ -155,15 +165,6 @@ function NavButtonBox({activePage, numPages, changePage, submitLabel}
                                 next&nbsp;&raquo;
                             </Button>
                     }
-                    <Button
-                        colours={'secondary'}
-                        htmlType={'button'}
-                        size={'twin'}
-                        onClick={() => activePage === 1 ? undefined : changePage(activePage - 1)}
-                        disabled={activePage === 1}
-                        >
-                        &laquo;&nbsp;back
-                    </Button>
                 </div>
             </div>
 }

--- a/app/components/timeGroup/subcomponents/heading.tsx
+++ b/app/components/timeGroup/subcomponents/heading.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { T_TimeGroup, T_GameState } from '../../../utils/types';
-import { calcDHMString, convertTimeIDToTimeRemaining, convertTimeIDToDate, getDateDisplayStr } from '../../../utils/dateAndTimeHelpers';
+import { calcDHMString, convertTimeIDToTimeRemaining, convertTimeIDToDate, calcDateDisplayStr } from '../../../utils/dateAndTimeHelpers';
 import { MAX_TIME } from '../../../utils/consts';
 
 import { IconMoon } from '../../subcomponents/icons';
@@ -30,9 +30,9 @@ export default function TimeGroupHeading({data, gameState} : I_TimeGroupHeading)
                         convertTimeIDToDate(data.startOfflinePeriodTimeID, gameState)
                         : null;
 
-    let shortDisplayStr = getDateDisplayStr(timeAsDate);
+    let shortDisplayStr = calcDateDisplayStr(timeAsDate);
     let fullDisplayStr = startAsDate !== null ? 
-                            getDateDisplayStr(startAsDate) + " - " + shortDisplayStr
+                            calcDateDisplayStr(startAsDate) + " - " + shortDisplayStr
                             : shortDisplayStr;
 
     return(

--- a/app/components/timeGroup/timeGroupMore/subcomponents/sectionDustStats.tsx
+++ b/app/components/timeGroup/timeGroupMore/subcomponents/sectionDustStats.tsx
@@ -2,7 +2,7 @@ import { useRef, MutableRefObject } from "react";
 
 import { MAX_TIME } from "@/app/utils/consts";
 import { nbsp, toBillions, resourceCSS } from "@/app/utils/formatting";
-import { convertTimeIDToDate, convertTimeIDToTimeRemaining, calcDHMString, getMonthName } from "@/app/utils/dateAndTimeHelpers";
+import { convertTimeIDToDate, convertTimeIDToTimeRemaining, calcDHMString, calcMonthName } from "@/app/utils/dateAndTimeHelpers";
 
 import { I_MoreSections } from "../utils/types";
 import TimeGroupMoreSubheading from './subheading';
@@ -26,7 +26,7 @@ export default function DustStatsSection({moreData, gameState, leftHeadingWidth}
             let timeStr = `${date.getHours().toString().padStart(2, "0")}:${date.getMinutes().toString().padStart(2, "0")}`;
            
             let DHM = convertTimeIDToTimeRemaining(MAX_TIME - timeID);
-            return `${calcDHMString(DHM)} ${dateStr}${nbsp()}${getMonthName(date.getMonth())}${nbsp()}${timeStr}`;
+            return `${calcDHMString(DHM)} ${dateStr}${nbsp()}${calcMonthName(date.getMonth())}${nbsp()}${timeStr}`;
         }
 
         return timeID === -1 ?

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,6 +15,7 @@ import StickyBar from './components/stickyBar';
 import DisplayUserInput from './components/sectionDisplayUserInput';
 import ErrorWithPlanner from './components/errorWithPlanner';
 
+
 export default function Home() {
   
   const { gameState, setGameState, 
@@ -112,6 +113,7 @@ function Modals({modals} : { modals : { [key : string] :  T_ModalData} }){
                     closeModal={ modals.gameState.closeModal } 
                     setGameState={ modals.gameState.action } 
                     gameState={ modals.gameState.data.gameState } 
+                    mode={ modals.gameState.data.mode }
                   />
                   : modals.offlinePeriods.isVisible ?
                     <OfflineForm 

--- a/app/utils/calcPlanData.tsx
+++ b/app/utils/calcPlanData.tsx
@@ -2,7 +2,6 @@ import { calcProductionRates } from './calcProductionRates';
 import { calcStockpilesAdvancedByTime } from './calcStockpilesAdvancedByTime';
 import { calcDustAtEndWithMaxDustProduction } from './calcResults';
 import { MAX_TIME, OUT_OF_TIME, deepCopy } from './consts';
-import { calcStartTime as calcStartTime} from './dateAndTimeHelpers';
 import { T_DATA_COSTS, T_DATA_KEYS, getProductionCostsFromJSON } from './getDataFromJSON';
 import { isDuringOfflinePeriod, getOfflinePeriodAsTimeIDs } from './offlinePeriodHelpers';
 import { calcProductionSettings as calcProductionSettings } from './productionSettingsHelpers';
@@ -63,7 +62,7 @@ export default function calcPlanData({ gameState, actions, offlinePeriods, prodS
     let productionSettingsBeforeNow : T_ProductionSettings = deepCopy(productionSettingsBeforeFirstAction);
     let flagFirstIsDone = false;
 
-    const startedAt : Date = calcStartTime(gameState);
+    const startedAt : Date = gameState.startTime;
     let stockpiles : T_Stockpiles = deepCopy(gameState.stockpiles);
     let levels : T_Levels = deepCopy(gameState.levels);
     let productionSettings : T_ProductionSettings = deepCopy(productionSettingsBeforeFirstAction);

--- a/app/utils/calcResults.tsx
+++ b/app/utils/calcResults.tsx
@@ -4,7 +4,7 @@ import { calcStockpilesAdvancedByTime } from './calcStockpilesAdvancedByTime';
 import { T_DATA_KEYS, getWorkerOutputsFromJSON } from "./getDataFromJSON";
 import { T_Levels, T_SuggestionData, T_ResultData, T_Action, T_PurchaseData, T_PremiumInfo, T_ProductionSettings, T_AllToDustOutput, T_GameState, T_TimeGroup, T_Stockpiles } from "./types";
 import { calcProductionSettings } from "./productionSettingsHelpers";
-import { defaultProductionSettings } from "./defaults";
+import { startingProductionSettings } from "./defaults";
 
 
 
@@ -32,7 +32,7 @@ export function calcDustAtEndWithMaxDustProduction({timeID, stockpiles, levels, 
 }
 
 
-export function calcMaxDustRate(levels : T_Levels, premiumInfo : T_PremiumInfo, productionSettings : T_ProductionSettings = defaultProductionSettings){
+export function calcMaxDustRate(levels : T_Levels, premiumInfo : T_PremiumInfo, productionSettings : T_ProductionSettings = startingProductionSettings){
     const dustySettings : T_ProductionSettings = productionSettingsAllToDust(productionSettings);
     return calcProductionRate('dust', levels, premiumInfo, dustySettings);
 }

--- a/app/utils/dateAndTimeHelpers.tsx
+++ b/app/utils/dateAndTimeHelpers.tsx
@@ -6,8 +6,7 @@ import { MS_PER_MINUTE } from './consts';
 export function convertDateToTimeID(targetTime : Date, gameState : T_GameState) 
     : number {
 
-    let startedAt : Date = calcStartTime(gameState);
-    let difference =  Math.abs(targetTime.getTime() - startedAt.getTime());
+    let difference =  Math.abs(targetTime.getTime() - gameState.startTime.getTime());
     return Math.round(difference / MS_PER_MINUTE);
 }
 
@@ -15,8 +14,7 @@ export function convertDateToTimeID(targetTime : Date, gameState : T_GameState)
 export function convertTimeIDToDate(targetTimeID : number, gameState : T_GameState) 
     : Date {
 
-    let startedAt : Date = calcStartTime(gameState);
-    return new Date(startedAt.getTime() + targetTimeID * MS_PER_MINUTE);
+    return new Date(gameState.startTime.getTime() + targetTimeID * MS_PER_MINUTE);
 }
 
 export function convertTimeIDToDHM(timeId: number)
@@ -72,7 +70,9 @@ export function calcDHMString(timeAsDHM : T_TimeRemainingDHM) : string {
 }
 
 
-export function calcStartTime(
+
+
+function OLDcalcStartTime(
     gameState : T_GameState) 
     : Date {
         
@@ -90,7 +90,7 @@ export function calcStartTime(
 }
 
 
-export function getMonthName(monthNumber : number) : string {
+export function calcMonthName(monthNumber : number) : string {
     const date = new Date();
     date.setMonth(monthNumber);
   
@@ -99,8 +99,8 @@ export function getMonthName(monthNumber : number) : string {
 }
 
 
-export function getDateDisplayStr(myDate : Date) : string {
-    return myDate.getDate().toString().padStart(2, '0') + nbsp() + getMonthName(myDate.getMonth()) + nbsp() + myDate.toLocaleTimeString([], {timeStyle: 'short', hourCycle: 'h23' });
+export function calcDateDisplayStr(myDate : Date) : string {
+    return myDate.getDate().toString().padStart(2, '0') + nbsp() + calcMonthName(myDate.getMonth()) + nbsp() + myDate.toLocaleTimeString([], {timeStyle: 'short', hourCycle: 'h23' });
 }
 
 export function printOfflineTime(dhm : T_TimeOfflinePeriod) : string{

--- a/app/utils/defaults.tsx
+++ b/app/utils/defaults.tsx
@@ -2,13 +2,13 @@ import { deepCopy, MAX_TIME } from './consts';
 import { T_DATA_KEYS, getMainKeysFromJSON, getMaxLevelFromJSON, getUpgradesDataFromJSON } from './getDataFromJSON';
 import { T_GameState, T_Action, T_TimeRemainingDHM, T_Levels, T_Stockpiles, T_ProductionSettings, T_TimeOfflinePeriod } from './types';
 
-export const defaultTimeRemaining : T_TimeRemainingDHM = {
+export const startingTimeRemaining : T_TimeRemainingDHM = {
     days: 3,
     hours: 0,
     minutes: 0
 }
 
-export const defaultStockpiles : T_Stockpiles = {
+export const startingStockpiles : T_Stockpiles = {
     dust: 0,
     blue: 0,
     green: 0,
@@ -16,7 +16,7 @@ export const defaultStockpiles : T_Stockpiles = {
     yellow: 0,
 }
 
-export const defaultProductionSettings : T_ProductionSettings = {
+export const startingProductionSettings : T_ProductionSettings = {
     trinity: "blue",
     bronte: "green",
     anne: "blue",
@@ -27,7 +27,7 @@ export const defaultProductionSettings : T_ProductionSettings = {
     rex: "dust",
 }
 
-export const defaultLevels : T_Levels = {
+export const startingLevels : T_Levels = {
     trinity : 0,
     bronte : 0,
     anne : 0,
@@ -46,17 +46,18 @@ export const defaultLevels : T_Levels = {
 
 export const defaultGameState : T_GameState = {
     timeEntered : new Date(),
+    startTime : new Date(),
     timeRemaining : MAX_TIME,
     premiumInfo :  {
     adBoost : false,
     allEggs : 0,
     },
-    stockpiles : deepCopy(defaultStockpiles),
-    levels : deepCopy(defaultLevels),
+    stockpiles : deepCopy(startingStockpiles),
+    levels : deepCopy(startingLevels),
 }
 
 export const maxLevels = () => {
-    let maxLevels = deepCopy(defaultLevels);
+    let maxLevels = deepCopy(startingLevels);
     Object.keys(maxLevels).forEach(key => {
         maxLevels[key] = getMaxLevelFromJSON(key as T_DATA_KEYS);
     });
@@ -66,7 +67,7 @@ export const maxLevels = () => {
 export const defaultOfflinePeriodStart : T_TimeOfflinePeriod = {
     dateOffset: 0,
     hours: 0,
-     minutes: 0
+    minutes: 0
 }
 
 export const defaultOfflinePeriodEnd : T_TimeOfflinePeriod = {

--- a/app/utils/productionSettingsHelpers.tsx
+++ b/app/utils/productionSettingsHelpers.tsx
@@ -1,5 +1,5 @@
 import { deepCopy } from './consts';
-import { defaultProductionSettings } from './defaults';
+import { startingProductionSettings } from './defaults';
 import { T_Action, T_DisplaySwitch as T_SwitchDisplay, T_ProductionSettings, T_TimeGroup } from './types';
 
 
@@ -7,7 +7,7 @@ export function calcProductionSettings({actions, index}
     : {actions : T_Action[], index : number})
     : T_ProductionSettings {
 
-    let result = deepCopy(defaultProductionSettings);
+    let result = deepCopy(startingProductionSettings);
 
     let prodSwitchesOnly = actions.slice(0, index).filter((ele) => ele.type === 'switch');
     for(let i = 0; i < prodSwitchesOnly.length; i++){

--- a/app/utils/types.tsx
+++ b/app/utils/types.tsx
@@ -2,6 +2,7 @@ import { SetStateAction, Dispatch } from "react";
 
 export type T_GameState = {
     timeEntered : Date,
+    startTime : Date,
     timeRemaining : number,
     premiumInfo : T_PremiumInfo,
     stockpiles : T_Stockpiles,

--- a/app/utils/useGameStateModal.tsx
+++ b/app/utils/useGameStateModal.tsx
@@ -4,6 +4,8 @@
 import { Dispatch, SetStateAction, useState } from "react";
 import { T_GameState, T_ModalData } from "./types";
 
+import { usePlanMode } from "./usePlanMode";
+
 
 interface I_UseGameStateModal {
     gameState : T_GameState,
@@ -27,7 +29,8 @@ export default function useGameStateModal({gameState, setGameState}
         closeModal: () => setShowGameStateModal(false),
         action: setGameState,
         data: {
-          gameState
+          gameState,
+          mode: usePlanMode()
         }
     }
 }

--- a/app/utils/usePlanMode.tsx
+++ b/app/utils/usePlanMode.tsx
@@ -1,0 +1,22 @@
+import { useState, SetStateAction, Dispatch } from "react";
+
+export enum PlanMode {
+    "active",
+    "plan"
+}
+
+export type T_PlanModeKit = {
+    isPlan: boolean,
+    isActive: boolean,
+    setMode: Dispatch<SetStateAction<PlanMode | null>>,
+}
+
+export function usePlanMode(){
+    const [mode, setMode] = useState<PlanMode | null>(null);
+
+    return {
+        isPlan: mode === PlanMode.plan,
+        isActive: mode === PlanMode.active,
+        setMode : setMode
+    }
+}

--- a/app/utils/usePlanner.tsx
+++ b/app/utils/usePlanner.tsx
@@ -4,7 +4,6 @@
 import { useState, useEffect } from "react";
 
 import { defaultActionsList, defaultGameState } from './defaults';
-import { calcStartTime } from "./dateAndTimeHelpers";
 import calcPlanData from './calcPlanData';
 import { calcTimeGroups } from './calcTimeGroups';
 import { T_TimeGroup, T_OfflinePeriod, T_GameState, T_Action, T_ProductionSettingsNow } from './types';


### PR DESCRIPTION
"Plan mode" added, improving UX for users planning their event in advance.

* The first time the game state modal is opened it shows a new page asking the user to select their "input mode": active or plan
* On subsequent openings, the game state model will skip the selection page and go straight to the same mode as last time
* On subsequent openings, "change mode" button added to both active and plan forms: this will display the mode selection page
* Previous game state form now appears as "active mode"
* New form added for "plan mode", containing inputs for start time, ad boost and all eggs
* startTime property added to gameState and uses of calcStartTime updated to use the property instead
* calcStartTime moved from dateAndTimeHelpers to the hook for the active gameState form, where it is used to set gameState.startTime
* Constants called 'defaultX' which were used as starting values have been renamed to 'startingX' to clarify their usage