### PR TITLE
Adjust game state display based on mode

### DIFF
--- a/app/components/forms/gameState/gameState.tsx
+++ b/app/components/forms/gameState/gameState.tsx
@@ -2,7 +2,7 @@ import { Dispatch, SetStateAction, useState, ChangeEvent } from 'react';
 
 import { T_DATA_KEYS, getUnitDataFromJSON } from '@/app/utils/getDataFromJSON';
 import { T_GameState } from '@/app/utils/types';
-import { T_PlanModeKit } from '@/app/utils/usePlanMode';
+import { PlanMode, T_PlanModeKit } from '@/app/utils/usePlanMode';
 
 import { BadgeCost, BadgeMaxed } from '../../subcomponents/badges';
 import Modal, { ModalFieldsWrapper, ModalHeading } from '../../subcomponents/modal';
@@ -19,23 +19,23 @@ import ChangeModeButton from './subcomponents/changeModeButton';
 export interface I_StatusFormSharedProps {
     setGameState : Dispatch<SetStateAction<T_GameState>>,
     gameState : T_GameState,
-    closeModal : () => void
+    closeModal : () => void,
 }
-export default function StatusForm({setGameState, gameState, mode, closeModal}
-    : I_StatusFormSharedProps & { mode : T_PlanModeKit })
+export default function StatusForm({setGameState, gameState, modeKit, closeModal}
+    : I_StatusFormSharedProps & { modeKit : T_PlanModeKit })
     : JSX.Element {
 
     const [userWantsToChangeMode, setUserWantsToChangeMode] = useState(false);
-    const [isInitialisingMode, _] = useState<boolean>(!mode.isActive && !mode.isPlan);
+    const [isInitialisingMode, _] = useState<boolean>(modeKit.mode !== PlanMode.active && modeKit.mode !== PlanMode.plan);
 
     return (
         <Modal closeModal={closeModal}>
-            <ModalHeading>{mode.isActive ? "Active" : "Plan"} Game Status</ModalHeading>
+            <ModalHeading>{modeKit.mode !== PlanMode.active ? "Active" : "Plan"} Game Status</ModalHeading>
             { !isInitialisingMode && !userWantsToChangeMode ?
                 <ChangeModeButton changeMode={() => setUserWantsToChangeMode(true)} />
                 : null
             }
-            { mode.isActive && !userWantsToChangeMode ?
+            { modeKit.mode === PlanMode.active && !userWantsToChangeMode ?
                 <FormActiveMode 
                     gameState={gameState}
                     setGameState={setGameState}   
@@ -43,7 +43,7 @@ export default function StatusForm({setGameState, gameState, mode, closeModal}
                     changeMode={() => setUserWantsToChangeMode(true)}
                     wantBackToMode={isInitialisingMode}
                 />
-                : mode.isPlan && !userWantsToChangeMode ?
+                : modeKit.mode === PlanMode.plan && !userWantsToChangeMode ?
                     <FormPlanMode 
                         gameState={gameState}          
                         setGameState={setGameState}        
@@ -52,9 +52,8 @@ export default function StatusForm({setGameState, gameState, mode, closeModal}
                     />
                     : 
                     <FormSetMode 
-                        isActive={ mode.isActive }
-                        isPlan={ mode.isPlan }
-                        setMode={ mode.setMode }
+                        mode={ modeKit.mode }
+                        setMode={ modeKit.setMode }
                         close={() => setUserWantsToChangeMode(false)}
                     />
             }

--- a/app/components/forms/gameState/subcomponents/formSetMode.tsx
+++ b/app/components/forms/gameState/subcomponents/formSetMode.tsx
@@ -11,7 +11,7 @@ interface I_ModeSetter extends T_PlanModeKit{
     close : () => void,
 }
 
-export default function FormSetMode({ isActive, isPlan, setMode, close } 
+export default function FormSetMode({ mode, setMode, close } 
     : I_ModeSetter) 
     : JSX.Element {
 
@@ -25,8 +25,8 @@ export default function FormSetMode({ isActive, isPlan, setMode, close }
         close();
     }
 
-    const planIsSelected = controlled === null && isPlan || controlled === PlanMode.plan;
-    const activeIsSelected = controlled === null && isActive || controlled === PlanMode.active;
+    const planIsSelected = (controlled === null && mode === PlanMode.plan) || controlled === PlanMode.plan;
+    const activeIsSelected = (controlled === null && mode === PlanMode.active) || controlled === PlanMode.active;
     return  <form onSubmit={(e) => onSubmit(e)}>
                 <InputPageWrapper isVisible={true}>
                     <fieldset className={"flex flex-col gap-6"}>
@@ -75,7 +75,7 @@ export default function FormSetMode({ isActive, isPlan, setMode, close }
                     size={"default"}
                     colours={"primary"}
                     htmlType={"submit"}
-                    disabled={ !isActive && !isPlan && controlled === null }
+                    disabled={ mode !== PlanMode.active && mode !== PlanMode.plan && controlled === null }
                     >
                     next&nbsp;&raquo;
                 </Button>

--- a/app/components/sectionDisplayUserInput.tsx
+++ b/app/components/sectionDisplayUserInput.tsx
@@ -1,4 +1,5 @@
 import { T_GameState, T_OfflinePeriod } from '../utils/types';
+import { PlanMode } from '../utils/usePlanMode';
 
 import { Button } from './forms/subcomponents/buttons';
 import SectionGameState from './sectionGameState';
@@ -8,6 +9,7 @@ import SectionOfflinePeriods from './sectionOfflinePeriods';
 interface I_DisplayUserInput {
     gameState : T_GameState,
     openGameStateModal : () => void,
+    mode : PlanMode,
     offlinePeriods : T_OfflinePeriod[],
     openOfflinePeriodsModal : (idx : number | null) => void,
     offlinePeriodIdxEdit : number | null,
@@ -15,7 +17,7 @@ interface I_DisplayUserInput {
     showOfflinePeriods : boolean
 }
 
-export default function DisplayUserInput({gameState, openGameStateModal, offlinePeriods, openOfflinePeriodsModal, offlinePeriodIdxEdit, showGameState, showOfflinePeriods}
+export default function DisplayUserInput({gameState, openGameStateModal, mode, offlinePeriods, openOfflinePeriodsModal, offlinePeriodIdxEdit, showGameState, showOfflinePeriods}
     : I_DisplayUserInput)
     : JSX.Element {
 
@@ -34,6 +36,7 @@ export default function DisplayUserInput({gameState, openGameStateModal, offline
                         <SectionGameState   
                             gameState={gameState}
                             openEditForm={openGameStateModal}
+                            mode={mode}
                         />
                     </StickyBarSection>
 
@@ -49,8 +52,6 @@ export default function DisplayUserInput({gameState, openGameStateModal, offline
                 </section>
             </div>
 }
-
-
 
 
 function StickyBarSection({extraCSS, children} 

--- a/app/components/subcomponents/stockpilesStrip.tsx
+++ b/app/components/subcomponents/stockpilesStrip.tsx
@@ -12,7 +12,7 @@ export default function StockpilesDisplay({stockpiles, extraCSS}
     : JSX.Element {
 
     return (
-        <div className={"flex" + " " + extraCSS}>
+        <div className={`flex ${extraCSS}`}>
             <Stockpile myKey={'blue'} data={stockpiles} />
             <Stockpile myKey={'green'} data={stockpiles} />
             <Stockpile myKey={'red'} data={stockpiles} />
@@ -27,7 +27,7 @@ function Stockpile({myKey, data}
     : JSX.Element {
 
     return (
-        <div className={"flex justify-between text-sm w-1/4 px-1 gap-1 rounded" + " " + resourceCSS[myKey as keyof typeof resourceCSS].badge}>
+        <div className={`flex justify-between text-sm w-1/4 px-1 gap-1 rounded ${resourceCSS[myKey as keyof typeof resourceCSS].badge}`}>
             <div>{myKey.charAt(0).toLowerCase()}</div>
             <div>{toThousands(data[myKey as keyof typeof data])}</div>
         </div>

--- a/app/components/timeGroup/timeGroupMore/subcomponents/sectionDustStats.tsx
+++ b/app/components/timeGroup/timeGroupMore/subcomponents/sectionDustStats.tsx
@@ -44,9 +44,9 @@ export default function DustStatsSection({moreData, gameState, leftHeadingWidth}
             <div className={"flex flex-col gap-2 mt-1"}>
                 <DustRowWrapper>
                     <DustSubheading leftHeadingWidth={leftHeadingWidth}>
-                        Stockpiled
+                        stockpile
                     </DustSubheading>
-                    <div className={"font-medium flex flex-col items-end justify-center w-48 px-1 py-0.5 border" + " " + resourceCSS.dust.cell}>
+                    <div className={`font-medium flex flex-col items-end justify-center w-48 px-1 py-0.5 border-l-4 ${resourceCSS.dust.field}`}>
                         {`${moreData.dustNow.toLocaleString()}`}&nbsp;{`(${toBillions(moreData.dustNow)})`}
                     </div>
                 </DustRowWrapper>
@@ -54,9 +54,9 @@ export default function DustStatsSection({moreData, gameState, leftHeadingWidth}
                     <table className={"w-full border-collapse"}>
                         <thead>
                             <tr>
-                                <th className={"" + " " + leftHeadingWidth}></th>
+                                <th className={leftHeadingWidth}></th>
                                 <th className={"w-24 text-center border bg-violet-300 border-violet-400 text-black"}>current</th>
-                                <th className={"w-24 text-center border" + " " + resourceCSS.dust.badge}>max&nbsp;dust</th>
+                                <th className={`w-24 text-center border ${resourceCSS.dust.badge}`}>max&nbsp;dust</th>
                             </tr>
                         </thead>
                         <tbody>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -36,7 +36,7 @@ export default function Home() {
   const { save : saveModal, load: loadModal } = useSaveAndLoad({actions, setActions, offlinePeriods, setOfflinePeriods, gameState, setGameState});
 
   return (
-    <main className={"flex justify-center bg-violet-200 min-h-screen"}>
+    <main className={"flex justify-center bg-violet-50 min-h-screen"}>
 
       <Modals modals={ {
                 save: saveModal,
@@ -58,6 +58,7 @@ export default function Home() {
           showGameState={showGameState}
           gameState={gameState}
           openGameStateModal={ gameStateModal.openModal }
+          mode={ gameStateModal.data.mode.mode }
 
           showOfflinePeriods={showOfflinePeriods}
           offlinePeriods={offlinePeriods}
@@ -113,7 +114,7 @@ function Modals({modals} : { modals : { [key : string] :  T_ModalData} }){
                     closeModal={ modals.gameState.closeModal } 
                     setGameState={ modals.gameState.action } 
                     gameState={ modals.gameState.data.gameState } 
-                    mode={ modals.gameState.data.mode }
+                    modeKit={ modals.gameState.data.mode }
                   />
                   : modals.offlinePeriods.isVisible ?
                     <OfflineForm 

--- a/app/styles.css
+++ b/app/styles.css
@@ -19,18 +19,6 @@
     grid-template-rows: auto auto;
 }
 
-.gameStateDisplayTimeAndPremium{
-    display: grid;
-    grid-template-columns: repeat(3, 33%);
-    max-width: 320px;
-}
-
-.gameStateDisplayDust{
-    display: grid;
-    grid-template-columns: 33% 1fr 4rem;
-    max-width: 320px;
-}
-
 .desktopBarsLayout{
     display: grid;
     grid-template-rows: auto auto auto;

--- a/app/utils/formatting.tsx
+++ b/app/utils/formatting.tsx
@@ -5,26 +5,31 @@ export const resourceCSS = {
         badge: "bg-sky-700 text-white border-sky-800",
         hover: "hover:bg-sky-600 hover:opacity-100",
         cell : "bg-sky-50 border-sky-300",
+        field: "border-sky-700 bg-sky-100",
     },
     green: {
         badge: "bg-green-700 text-white border-green-800",
         hover: "hover:bg-green-600 hover:opacity-100",
         cell : "bg-green-50 border-green-300",
+        field: "border-green-700 bg-green-100",
     },
     red: {
         badge: "bg-red-700 text-white border-red-800",
         hover: "hover:bg-red-600 hover:opacity-100",
         cell : "bg-red-50 border-red-300",
+        field: "border-red-700 bg-red-100",
     },
     yellow: {
         badge: "bg-amber-400 text-black font-bold border-amber-500",
         hover: "hover:bg-amber-300 hover:opacity-100",
         cell : "bg-amber-50 border-amber-300",
+        field: "border-amber-500 bg-amber-100",
     },
     dust: {
         badge: "bg-lime-300 text-black font-bold border-lime-500",
         hover: "hover:bg-lime-200 text-black hover:opacity-100",
         cell : "bg-lime-50 border-lime-400 text-black",
+        field: "border-lime-500 bg-lime-200",
     },
 
 }
@@ -34,17 +39,16 @@ export function nbsp(){
 }
 
 export function toThousands(num : number) : string {
-    return num < 1000 ? num.toString() : `${ Math.floor(num / 1000).toLocaleString() }k`;
+    return num < 1000 ? num.toLocaleString() : `${ Math.floor(num / 1000).toLocaleString() }k`;
 }
 
 export function toMillions(num : number) : string {
-    return num < 1000000 ? num.toString() : `${ Math.floor(num / 1000000).toLocaleString() }M`;
+    return num < 1000000 ? num.toLocaleString() : `${ Math.floor(num / 1000000).toLocaleString() }M`;
 }
 
 export function toBillions(num : number) : string {
     return num < 1000000000 ? `<1B` : `${ Math.floor(num / 1000000000).toLocaleString() }B`;
 }
-
 
 export function capitalise(str : string) : string {
     return `${str.charAt(0).toUpperCase()}${str.slice(1)}`;

--- a/app/utils/usePlanMode.tsx
+++ b/app/utils/usePlanMode.tsx
@@ -6,8 +6,7 @@ export enum PlanMode {
 }
 
 export type T_PlanModeKit = {
-    isPlan: boolean,
-    isActive: boolean,
+    mode : PlanMode | null,
     setMode: Dispatch<SetStateAction<PlanMode | null>>,
 }
 
@@ -15,8 +14,7 @@ export function usePlanMode(){
     const [mode, setMode] = useState<PlanMode | null>(null);
 
     return {
-        isPlan: mode === PlanMode.plan,
-        isActive: mode === PlanMode.active,
+        mode,
         setMode : setMode
     }
 }


### PR DESCRIPTION
When the user has selected "plan mode" and entered only a start time and premium info, it's very confusing to confront them with a panel displaying the full game state, because that includes several irrelevant in-progress variables which they didn't enter and can't alter.

It's also a little confusing for users who picked "active mode" to have a start time variable in the middle of their information, when they have no means of directly altering this.

To resolve that confusion, the game state display panel now limits its fields to those relevant to the currently selected input mode.

Related small adjustments:
* Amended usePlan to return the actual mode instead of "isActive" and "isPlan". I'd been hoping to avoid importing the enum everywhere, but it felt messy
* Altered the width of the labels in the game state display so that the displayed values would line up with the end of the edit button, improving the appearance in plan mode
* Moved custom grid CSS from styles.css into the className string: now that I know you can do that, I'd rather have all the CSS in one place
* Adjusted appearance of dust stockpile
* In the timeGroup's "more" panel, updated the appearance of the dust stockpile to match the new appearance in game state display
* In the timeGroup's "more" panel, changed the dust label from "Stockpiled" to "stockpile" for consistency with the eggs table
* Renamed some labels for clarity