### PR TITLE
fix/feat: improved handling of zero production

### DIFF
--- a/app/components/planner/subcomponents/controlsRow.tsx
+++ b/app/components/planner/subcomponents/controlsRow.tsx
@@ -17,7 +17,7 @@ export default function ControlsRow({displaySwitches, showUpgradeButton, handleP
                                             "w-20"
                                             : "w-40";
     return(
-        <div className={"flex justify-between px-1 py-1 plnMd:justify-start plnMd:grid plnMd:gap-4 plnMd:grid-rows-1 plnMd:[grid-template-columns:18rem_auto]"}>
+        <div className={"w-full plnMd:w-min flex justify-between px-1 py-1 plnMd:justify-start plnMd:grid plnMd:gap-4 plnMd:grid-rows-1 plnMd:[grid-template-columns:18rem_auto]"}>
             
             {showUpgradeButton ?
             <div className={'flex flex-col justify-start plnMd:[grid-column-start:1] plnMd:justify-self-start plnMd:self-start'}>

--- a/app/components/planner/utils/useSwitchProductionNow.tsx
+++ b/app/components/planner/utils/useSwitchProductionNow.tsx
@@ -30,7 +30,6 @@
 import { MutableRefObject, useState } from 'react';
 
 import { convertDateToTimeID } from '../../../utils/dateAndTimeHelpers';
-import { maxLevels } from '../../../utils/defaults';
 import { I_ProductionSwitcherModalUniversal, T_ProductionSettings, T_TimeGroup, T_GameState, T_Levels, T_ProductionSettingsNow } from '../../../utils/types';
 import { exactMatch } from '../../../utils/productionSettingsHelpers';
 
@@ -82,7 +81,7 @@ export function useSwitchProductionNow({ initialProdSettings, setProdSettingsNow
         closeModal: () => setIsVisible(false),
         initialProdSettings,
         updateProdSettings: updateSettings,
-        levelsAtStart: timeIDGroups.length > 0 ? timeIDGroups[0].levelsAtEnd : maxLevels(),
+        levelsAtStart: gameState.levels,
         modalProps: {
             firstTimeGroup: timeIDGroups.length > 0 ? timeIDGroups[0] : undefined,
             gameState

--- a/app/components/subcomponents/badges.tsx
+++ b/app/components/subcomponents/badges.tsx
@@ -13,10 +13,10 @@ export function BadgeCost({data, extraCSS}
     extraCSS = extraCSS ?? "justify-between items-center px-2 py-0.5 rounded text-xs";
     
     return (
-        <div className={"flex" + " " + extraCSS + " " + resourceCSS[data.egg as keyof typeof resourceCSS].badge}>
+        <span className={"flex" + " " + extraCSS + " " + resourceCSS[data.egg as keyof typeof resourceCSS].badge}>
             <span className={"block mr-1"}>{data.egg.charAt(0)}</span>
             <span className={"block"}>{ displayQty }</span>
-        </div>
+        </span>
     )
 }
 

--- a/app/utils/calcResults.tsx
+++ b/app/utils/calcResults.tsx
@@ -1,4 +1,4 @@
-import { deepCopy, MAX_TIME, WIN_CONDITION } from "./consts";
+import { deepCopy, MAX_TIME, OUT_OF_TIME, WIN_CONDITION } from "./consts";
 import { calcProductionRates, calcProductionRate } from "./calcProductionRates";
 import { calcStockpilesAdvancedByTime } from './calcStockpilesAdvancedByTime';
 import { T_DATA_KEYS, getWorkerOutputsFromJSON } from "./getDataFromJSON";
@@ -75,7 +75,10 @@ export function calcResultOfPlan({ gameState, actions, timeIDGroups }
     });
     let dustAtEnd = stockpilesAtEnd === null ? -1 : stockpilesAtEnd.dust;
 
-    let allToDust = timeIDGroups.length > 0 ?
+    const hasAtLeastOneValidTimeGroup = timeIDGroups.length > 1 
+                                        || (timeIDGroups.length === 1 && timeIDGroups[0].timeID < OUT_OF_TIME);
+
+    let allToDust = hasAtLeastOneValidTimeGroup ?
         calcBestAllToDustFromTimeGroups({ timeIDGroups, dustAtEnd })
         : calcAllToDustAtEndFromNow({
             gameState,

--- a/app/utils/defaults.tsx
+++ b/app/utils/defaults.tsx
@@ -57,9 +57,9 @@ export const defaultGameState : T_GameState = {
 }
 
 export const maxLevels = () => {
-    let maxLevels = deepCopy(startingLevels);
+    let maxLevels : T_Levels = deepCopy(startingLevels);
     Object.keys(maxLevels).forEach(key => {
-        maxLevels[key] = getMaxLevelFromJSON(key as T_DATA_KEYS);
+        maxLevels[key as keyof typeof maxLevels] = getMaxLevelFromJSON(key as T_DATA_KEYS);
     });
     return maxLevels;
 }


### PR DESCRIPTION
Bug #1:
If the top production switch was used to adjust production and this resulted in zero production of an egg needed to purchase the first upgrade, the entire program would crash.

Cause:
If the first upgrade can't be purchased, there are no valid time groups. Some results calculations are based on there being at least one valid time group: they had a check for /zero/ time groups, but not for "one, but invalid",

Feature:
Fixing this raised the question: what /should/ users see in this case, apart from the insert and switch buttons they'd need to fix it? Added a message which explains which eggs are needed for the next upgrade and which of those have zero production. Since this message would also be useful if zero production occurred at the end of the plan, I set it up to work in both cases.

Bug #2:
The top production settings modal was initialising incorrectly when the first upgrade was a new worker: the new worker, who hadn't been unlocked yet and so should be disabled, was instead showing as available.

Small changes in support of these changes:
* Badge wrapper is now a span instead of a div so it can be used within a sentence span
* Added CSS to prevent ControlsRow's buttons from collapsing together
* While investigating the "zero production crash", I decided that Future!Me would not remember why I had half the handleSwitchAction work inside a block conditional on flagFirstisDone. What started as a more detailed comment ended with breaking up the function a little