### PR TITLE
fix: offline period validation and display

### DIFF
--- a/app/components/forms/gameState/subcomponents/pageGeneral.tsx
+++ b/app/components/forms/gameState/subcomponents/pageGeneral.tsx
@@ -1,6 +1,6 @@
 import { Dispatch, SetStateAction } from "react";
 
-import { calcDateDisplayStr } from '../../../../utils/dateAndTimeHelpers';
+import { calcDateWithTimeDisplayStr } from '../../../../utils/dateAndTimeHelpers';
 import { capitalise } from '../../../../utils/formatting';
 
 import { Button } from '../../subcomponents/buttons';
@@ -58,7 +58,7 @@ function Entered({timeEntered, setStateOnChange, setTimeEntered}
                 suppressHydrationWarning={true} 
                 className={"ml-2"}
                 >
-                { calcDateDisplayStr(timeEntered) }
+                { calcDateWithTimeDisplayStr(timeEntered) }
             </p>
             <input 
                 hidden 

--- a/app/components/forms/prodSettings.tsx
+++ b/app/components/forms/prodSettings.tsx
@@ -8,7 +8,7 @@ import { T_Levels, T_ProductionSettings, T_SwitchAction, } from '@/app/utils/typ
 import Modal, { ModalHeading, ModalSubmitButton, ModalFieldsWrapper, I_Modal } from '../subcomponents/modal';
 
 import Radio from './subcomponents/radio';
-import { calcDateDisplayStr, convertDateToTimeID } from "@/app/utils/dateAndTimeHelpers";
+import { calcDateWithTimeDisplayStr, convertDateToTimeID } from "@/app/utils/dateAndTimeHelpers";
 import { T_ProdSettingsNowModalProps } from "../planner/utils/useSwitchProductionNow";
 import { useCurrentMinute } from "./utils/useCurrentMinute";
 
@@ -228,7 +228,7 @@ function MessageForNow({firstTimeGroup, timeNow }:
     return  <p className={"mt-5 text-sm flex flex-col items-center gap-1 bg-white rounded py-2"}>
                 Adjusting settings starting from
                 <span className={"block font-semibold inline rounded px-1.5 py-0.5 bg-violet-100"}>
-                    {calcDateDisplayStr(timeNow)}
+                    {calcDateWithTimeDisplayStr(timeNow)}
                 </span>
             </p>
 }

--- a/app/components/planner/planner.tsx
+++ b/app/components/planner/planner.tsx
@@ -186,8 +186,7 @@ function TimeGroupsList({timeIDGroups, gameState, openUpgradePicker, openProdSwi
                 });
 
                 let nextPos = data.startPos + data.upgrades.length;
-                return <>
-                        <div key={'tgcr' + idx} className={"w-min"}>
+                return <div key={'tgcr' + idx} className={"w-min"}>
                             <TimeGroup 
                                 groupData={data} 
                                 startPos={data.startPos} 
@@ -202,7 +201,6 @@ function TimeGroupsList({timeIDGroups, gameState, openUpgradePicker, openProdSwi
                                 showUpgradeButton={ idx < timeIDGroups.length - 1 || purchasesPassTimeLimit }
                             />
                         </div>
-                    </>
             })}
         </>
 }

--- a/app/components/sectionDisplayUserInput.tsx
+++ b/app/components/sectionDisplayUserInput.tsx
@@ -30,7 +30,7 @@ export default function DisplayUserInput({gameState, openGameStateModal, mode, o
     }
 
     return  <div className={"sticky h-0 top-12 relative z-20 md:sticky md:[grid-area:status] md:[top:calc(7.5rem_+_1px)]"}>
-                <div className={`w-full bg-violet-900 flex flex-col items-center md:bg-transparent md:border-none md:shadow-none md:min-w-[20rem] md:[height:calc(100vh-10rem)] md:gap-3 md:px-3 md:pt-0 md:pb-1.5 ${containerVisibilityCSS}`}>
+                <div className={`w-full bg-violet-900 flex flex-col items-center md:bg-transparent md:border-none md:shadow-none md:min-w-[20rem] md:[height:calc(100vh-8rem)] md:gap-3 md:px-3 md:pt-0 md:pb-1.5 ${containerVisibilityCSS}`}>
                     
                     <DisplayInputSection title={"Game Status"} extraCSS={`md:mt-0 ${gameStateVisibilityCSS}`}>
                         <SectionGameState   
@@ -40,7 +40,7 @@ export default function DisplayUserInput({gameState, openGameStateModal, mode, o
                         />
                     </DisplayInputSection>
 
-                    <DisplayInputSection title={"Offline Periods"} extraCSS={offlinePeriodCSS}>
+                    <DisplayInputSection title={"Offline Periods"} extraCSS={`md:max-h-[calc(100vh-33rem)] ${offlinePeriodCSS}`}>
                         <SectionOfflinePeriods  
                             offlinePeriods={offlinePeriods}
                             gameState={gameState}
@@ -57,8 +57,9 @@ function DisplayInputSection({title, extraCSS, children}
     : {title : string, extraCSS : string, children : React.ReactNode})
     : JSX.Element {
 
+    const cssOverflowHandling = "overflow-y-auto overflow-x-hidden max-h-[calc(100vh-10rem)] flex-shrink-0";
     return(
-        <section className={`mt-1 mb-1 shadow-xl bg-white px-2 py-2 w-full max-w-xs rounded text-sm overflow-y-auto overflow-x-hidden max-h-[calc(100vh-5rem)] w-full pb-2 ${extraCSS}`}>
+        <section className={`mt-1 mb-1 px-2 py-2 w-full max-w-xs text-sm bg-white rounded shadow-xl ${cssOverflowHandling} ${extraCSS}`}>
             <h2 className={"text-lg font-bold ml-1 mb-3"}>{title}</h2>
             {children}
         </section>

--- a/app/components/sectionGameState.tsx
+++ b/app/components/sectionGameState.tsx
@@ -1,4 +1,4 @@
-import { calcDateDisplayStr, convertTimeIDToTimeRemaining } from '../utils/dateAndTimeHelpers';
+import { calcDateWithTimeDisplayStr, convertTimeIDToTimeRemaining } from '../utils/dateAndTimeHelpers';
 import { getUnitDataFromJSON, getMaxLevelFromJSON, T_DATA_KEYS } from "../utils/getDataFromJSON";
 import { resourceCSS, toBillions, nbsp, maxedLevelCSS, capitalise } from '../utils/formatting';
 import { T_Levels, T_GameState, T_Stockpiles } from '../utils/types';
@@ -43,7 +43,7 @@ function TimeAndPremiumStatus({gameState, mode}
                 { mode === PlanMode.active ?
                 <>
                 <GridRowWrapper title={"Updated"}>
-                    <dd suppressHydrationWarning={true}>{calcDateDisplayStr(gameState.timeEntered)}</dd>
+                    <dd suppressHydrationWarning={true}>{calcDateWithTimeDisplayStr(gameState.timeEntered)}</dd>
                 </GridRowWrapper>
 
                 <GridRowWrapper title={"Remaining"}>
@@ -55,7 +55,7 @@ function TimeAndPremiumStatus({gameState, mode}
 
                 { mode === PlanMode.plan ?
                 <GridRowWrapper title={"Start Time"}>
-                    <dd>{calcDateDisplayStr(gameState.startTime)}</dd>
+                    <dd>{calcDateWithTimeDisplayStr(gameState.startTime)}</dd>
                 </GridRowWrapper>
                 : null 
                 }

--- a/app/components/sectionOfflinePeriods.tsx
+++ b/app/components/sectionOfflinePeriods.tsx
@@ -1,4 +1,4 @@
-import { calcDateDisplayStr } from "../utils/dateAndTimeHelpers";
+import { calcDateDisplayStr, calcDateWithTimeDisplayStr, calcTimeDisplayStr } from "../utils/dateAndTimeHelpers";
 import { convertOfflineTimeToDate, printOfflineTime } from "../utils/offlinePeriodHelpers";
 import { T_GameState, T_OfflinePeriod } from "../utils/types";
 
@@ -19,8 +19,8 @@ export default function SectionOfflinePeriods({offlinePeriods, openModal, gameSt
     if(gameState === null){
         return null;
     }
-
-    return  <div className={'overflow-y-auto overflow-x-hidden max-h-[calc(100vh-5rem)] px-2'}>
+//overflow-y-auto overflow-x-hidden max-h-[calc(100vh-5rem)] plnMd:max-h-[22rem]
+    return  <div className={'px-2'}>
                 <OfflineDisplay offlinePeriods={offlinePeriods} gameState={gameState} openForm={openModal} idxEdit={idxEdit} />
                 <EditButtonBox openEditForm={() => openModal(null)} label={`add`} />
             </div>
@@ -37,43 +37,125 @@ function OfflineDisplay({offlinePeriods, gameState, openForm, idxEdit}
     : I_OfflineDisplay)
     : JSX.Element {
 
-    return <div>
-            { (offlinePeriods === undefined || offlinePeriods.length === 0) ?
-                <p>None entered</p>
-                :
-                <ol>
-                {offlinePeriods.map((ele, idx) => {
-                    let conditionalWrapperCSS = "";
-                    if(idxEdit === idx){
-                        conditionalWrapperCSS = "text-gray-300";
-                    }
+    const dayGroups = convertOfflinePeriodsToDayGroups(offlinePeriods);
+    const isEmpty = dayGroups === undefined || dayGroups.length === 0;
 
-                    let startDate : Date = convertOfflineTimeToDate(ele.start, gameState.startTime);
-                    let endDate : Date = convertOfflineTimeToDate(ele.end, gameState.startTime);
-
-                    return  <li key={`${printOfflineTime(ele.start)}_${printOfflineTime(ele.end)}`} className={"flex justify-between items-center mb-2" + " " + conditionalWrapperCSS}>
-                                <div className={"text-violet-800 font-bold"}>
-                                    {idx + 1}
-                                </div>
-                                <div>
-                                    {calcDateDisplayStr(startDate)} - {calcDateDisplayStr(endDate)}
-                                </div>
-
-                                <Button
-                                    size={'inline'}
-                                    colours={'secondary'}
-                                    onClick={() => openForm(idx)}
-                                    disabled={idxEdit === idx}
-                                >
-                                    edit
-                                </Button>
-                            </li>
-                })}
-                </ol>
-            }
+    return  <div className={"overflow-y-auto overflow-x-hidden max-h-[calc(100vh-10rem)] plnMd:max-h-[18rem]"}>
+                {
+                    isEmpty ?
+                        <p>None entered</p>
+                        :
+                        dayGroups.map((ele, idx) =>
+                            <DayGroup key={`offlinePeriodsDayGroup${idx}`}
+                                displayOfflinePeriods={ele} 
+                                gameState={gameState}
+                                openForm={openForm}
+                                idxEdit={idxEdit}
+                                dayGroupID={idx}
+                            />
+                        )
+                }
             </div>
+}
+
+
+function DayGroup({displayOfflinePeriods, gameState, openForm, idxEdit, dayGroupID} 
+    : Pick<I_OfflineDisplay, "gameState" | "idxEdit" | "openForm"> & { 
+        displayOfflinePeriods : T_OfflinePeriodDisplayData[],
+        dayGroupID : number
+    })
+    : JSX.Element{
+
+
+    const startDate : Date = displayOfflinePeriods.length === 0 ?
+        convertOfflineTimeToDate({dateOffset: dayGroupID, hours:0, minutes:0}, gameState.startTime)
+        : convertOfflineTimeToDate(displayOfflinePeriods[0].start, gameState.startTime);
+    
+    return  <section>
+                <h3 className={"font-semibold text-violet-700"}>
+                    {calcDateDisplayStr(startDate)}
+                </h3>
+                <div className={"pl-12 pr-2"}>
+                { displayOfflinePeriods.length === 0 ?
+                    <p className={"mb-2"}>None entered</p>
+                    :
+                    <ol>
+                    {
+                        displayOfflinePeriods.map(ele => 
+                            <OfflinePeriod key={`offlinePeriod${printOfflineTime(ele.start)}`}
+                                offlinePeriod={ele} 
+                                gameState={gameState} 
+                                isBeingEdited={idxEdit === ele.index}
+                                openForm={() => openForm(ele.index)}
+                            />)
+                    }
+                    </ol>
+                }
+                </div>
+            </section>
+
 
 }
 
 
+function OfflinePeriod({offlinePeriod, gameState, isBeingEdited, openForm}
+    : Pick<I_OfflineDisplay, "gameState"> & {
+        offlinePeriod : T_OfflinePeriodDisplayData,
+        isBeingEdited : boolean,
+        openForm : () => void,
+    })
+    : JSX.Element {
 
+    let conditionalWrapperCSS = "";
+    if(isBeingEdited){
+        conditionalWrapperCSS = "text-gray-300";
+    }
+
+    let startDate : Date = convertOfflineTimeToDate(offlinePeriod.start, gameState.startTime);
+    let endDate : Date = convertOfflineTimeToDate(offlinePeriod.end, gameState.startTime);
+
+    return  <li key={`${printOfflineTime(offlinePeriod.start)}_${printOfflineTime(offlinePeriod.end)}`} 
+                className={`grid [grid-template-columns:1fr_auto] grid-rows-1 items-center mb-2 ${conditionalWrapperCSS}`}
+                >
+                <div>
+                    { calcTimeDisplayStr(startDate) }
+                    {" - "}
+                    { startDate.getDate() === endDate.getDate() ? 
+                        calcTimeDisplayStr(endDate) 
+                        : calcDateWithTimeDisplayStr(endDate)
+                    }
+                </div>
+
+                <Button
+                    size={'inline'}
+                    colours={'secondary'}
+                    onClick={openForm}
+                    disabled={isBeingEdited}
+                >
+                    edit
+                </Button>
+            </li>
+}
+
+
+type T_OfflinePeriodDisplayData = T_OfflinePeriod & {
+    index : number
+}
+
+function convertOfflinePeriodsToDayGroups(offlinePeriods : T_OfflinePeriod[]){
+
+    if(offlinePeriods === undefined || offlinePeriods.length === 0){
+        return offlinePeriods;
+    }
+
+    const dayGroups : any[] = [[], [], [], []];
+
+    for(let i = 0; i < offlinePeriods.length; i++){
+        const op = offlinePeriods[i];
+        dayGroups[op.start.dateOffset].push({
+            ...op,
+            index: i
+        })
+    }
+    return dayGroups;
+}

--- a/app/components/timeGroup/subcomponents/heading.tsx
+++ b/app/components/timeGroup/subcomponents/heading.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { T_TimeGroup, T_GameState } from '../../../utils/types';
-import { calcDHMString, convertTimeIDToTimeRemaining, convertTimeIDToDate, calcDateDisplayStr } from '../../../utils/dateAndTimeHelpers';
+import { calcDHMString, convertTimeIDToTimeRemaining, convertTimeIDToDate, calcDateWithTimeDisplayStr } from '../../../utils/dateAndTimeHelpers';
 import { MAX_TIME } from '../../../utils/consts';
 
 import { IconMoon } from '../../subcomponents/icons';
@@ -30,9 +30,9 @@ export default function TimeGroupHeading({data, gameState} : I_TimeGroupHeading)
                         convertTimeIDToDate(data.startOfflinePeriodTimeID, gameState)
                         : null;
 
-    let shortDisplayStr = calcDateDisplayStr(timeAsDate);
+    let shortDisplayStr = calcDateWithTimeDisplayStr(timeAsDate);
     let fullDisplayStr = startAsDate !== null ? 
-                            calcDateDisplayStr(startAsDate) + " - " + shortDisplayStr
+                            calcDateWithTimeDisplayStr(startAsDate) + " - " + shortDisplayStr
                             : shortDisplayStr;
 
     return(

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -120,7 +120,6 @@ function Modals({modals} : { modals : { [key : string] :  T_ModalData} }){
                     <OfflineForm 
                         closeForm={ modals.offlinePeriods.closeModal } 
                         idxToEdit = { modals.offlinePeriods.data.idxToEdit }
-                        pos={ modals.offlinePeriods.data.pos }
                         offlinePeriod={ modals.offlinePeriods.data.offlinePeriod } 
                         offlinePeriods = { modals.offlinePeriods.data.offlinePeriods }
                         setOfflinePeriods = { modals.offlinePeriods.action }

--- a/app/utils/calcResults.tsx
+++ b/app/utils/calcResults.tsx
@@ -194,6 +194,7 @@ function calcMaxDustInfo(timeIDGroups : T_TimeGroup[])
     const maxDust = Math.max(...validTimeGroups.map(ele => ele.allToDustAfter !== null ? ele.allToDustAfter.value : 0));
     const maxDustTimeGroupIdx = validTimeGroups.findIndex(ele => ele.allToDustAfter !== null && maxDust === ele.allToDustAfter.value);
     const timeGroupWithMaxDust = timeIDGroups[maxDustTimeGroupIdx];
+
     return {
         max: maxDust,
         pos: timeGroupWithMaxDust.startPos + timeGroupWithMaxDust.upgrades.length - 1

--- a/app/utils/dateAndTimeHelpers.tsx
+++ b/app/utils/dateAndTimeHelpers.tsx
@@ -1,5 +1,5 @@
 import { nbsp } from './formatting';
-import { T_GameState, T_TimeOfflinePeriod, T_TimeRemainingDHM } from "./types";
+import { T_GameState, T_TimeRemainingDHM } from "./types";
 import { MS_PER_MINUTE } from './consts';
 
 
@@ -79,11 +79,20 @@ export function calcMonthName(monthNumber : number) : string {
 }
 
 
-export function calcDateDisplayStr(myDate : Date) : string {
-    return myDate.getDate().toString().padStart(2, '0') + nbsp() + calcMonthName(myDate.getMonth()) + nbsp() + myDate.toLocaleTimeString([], {timeStyle: 'short', hourCycle: 'h23' });
+export function calcDateWithTimeDisplayStr(myDate : Date) : string {
+    return calcDateDisplayStr(myDate) + nbsp() + calcTimeDisplayStr(myDate);
 }
 
-export function printOfflineTime(dhm : T_TimeOfflinePeriod) : string{
-    return `${dhm.dateOffset}d${dhm.hours}h${dhm.minutes}m`
+
+export function calcDateDisplayStr(myDate : Date) : string {
+    return myDate.getDate().toString().padStart(2, '0') + nbsp() + calcMonthName(myDate.getMonth());
 }
+
+export function calcTimeDisplayStr(myDate : Date) : string {
+    return myDate.toLocaleTimeString([], {timeStyle: 'short', hourCycle: 'h23' });
+}
+
+
+
+
 

--- a/app/utils/offlinePeriodHelpers.tsx
+++ b/app/utils/offlinePeriodHelpers.tsx
@@ -1,4 +1,4 @@
-import { MS_PER_MINUTE } from './consts';
+import { MAX_TIME, MS_PER_MINUTE, OUT_OF_TIME, deepCopy } from './consts';
 import { T_OfflinePeriod, T_TimeOfflinePeriod } from "./types";
 
 
@@ -55,13 +55,54 @@ export function convertOfflineTimeToDate(offlineTime : T_TimeOfflinePeriod, star
 export function convertOfflineTimeToTimeID(offlineTime : T_TimeOfflinePeriod, startedAt : Date)
     : number {
 
-    let targetDate = convertOfflineTimeToDate(offlineTime, startedAt);
-    let differenceInMs = targetDate.getTime() - startedAt.getTime();
-    return Math.round(differenceInMs / MS_PER_MINUTE);
+    const targetDate = convertOfflineTimeToDate(offlineTime, startedAt);
+    const differenceInMs = targetDate.getTime() - startedAt.getTime();
+    const differenceInMinutes = Math.round(differenceInMs / MS_PER_MINUTE);
+    
+    return 0 > differenceInMinutes ?
+            0
+            : MAX_TIME < differenceInMinutes ?
+                OUT_OF_TIME
+                : differenceInMinutes;
 }
 
 
 export function printOfflineTime(dhm : T_TimeOfflinePeriod) : string{
     return `${dhm.dateOffset}d${dhm.hours}h${dhm.minutes}m`
+}
+
+
+export function calcSortedOfflinePeriods(offlinePeriods : T_OfflinePeriod[]){
+    return offlinePeriods.toSorted((a, b) => {
+        const aStart = convertOfflineTimeToNumber(a.start);
+        const bStart = convertOfflineTimeToNumber(b.start);
+
+        return aStart < bStart ?
+                -1
+                : aStart > bStart ?
+                    1
+                    : 0;
+    });
+}
+
+
+// Used for comparing offline times to one another
+export function convertOfflineTimeToNumber(time : T_TimeOfflinePeriod){
+    const safeTime = fixOfflineTimeStrings(time);
+    return safeTime.dateOffset * 24 * 60 + safeTime.hours * 60 + safeTime.minutes;
+}
+
+
+// If load/save has somehow resulted in strings, fix that
+export function fixOfflineTimeStrings(offlineTime : T_TimeOfflinePeriod){
+    const dateInt = typeof offlineTime.dateOffset === 'string' ? parseInt(offlineTime.dateOffset) : offlineTime.dateOffset;
+    const hoursInt = typeof offlineTime.hours === 'string' ? parseInt(offlineTime.hours) : offlineTime.hours;
+    const minutesInt = typeof offlineTime.minutes === 'string' ? parseInt(offlineTime.minutes) : offlineTime.minutes;
+    
+    return {
+        dateOffset: dateInt,
+        hours: hoursInt,
+        minutes: minutesInt
+    }
 }
 

--- a/app/utils/types.tsx
+++ b/app/utils/types.tsx
@@ -56,13 +56,6 @@ export type T_TimeOfflinePeriod = {
     minutes : number
 }
 
-export type T_OfflinePeriodForm = 
-    T_OfflinePeriod & {
-        id: string,
-        isValid : boolean
-}
-
-
 export type T_Action = {
     type : string,
 } & (T_UpgradeAction | T_SwitchAction);

--- a/app/utils/useOfflinePeriodsModal.tsx
+++ b/app/utils/useOfflinePeriodsModal.tsx
@@ -44,7 +44,6 @@ export default function useOfflinePeriodsModal({offlinePeriods, setOfflinePeriod
             gameState,
             displayStr: "offline",
             offlinePeriod: idxToEdit === null ? null : offlinePeriods[idxToEdit],
-            pos: idxToEdit === null ? offlinePeriods.length + 1 : idxToEdit + 1,
         }
     }
 }


### PR DESCRIPTION
Bug:
Entering an offline period that spanned the entire event caused an empty plan with no indication of the cause of the problem.

Rejected:
Considered displaying an error message instead of an empty plan, but that would require a means to identify when the error is caused by offline periods. Doing so would require accounting for the following properties of offline periods:
* They can be of a longer duration than the event
* They can overlap
* They can be duplicated
* There can be any number of them

Conclusion:
Offline period form validation is too permissive. Better to prevent users from entering an offline period that would cause this error in the first place.

Changes:
* Form for offline periods has gained some extra validation rules. In addition to previous rules, there is now: a maximum of 150 periods; no overlapping; no duplicates; no being offline for the entire event
* Display of offline periods now shows them in order, grouped by date
* Edit modal now identifies the target offline period by its previous start and end times
* "Position numbers", previously used to identify the target offline period in the edit modal, have been removed
* Overflow-Y scrollbar added to the container with the dates and offline periods, so the heading and add button remain visible
* calcDateDisplayStr has been renamed to calcDateWithTimeDisplayStr, to more accurately reflect its output
* Date and time can now be formatted separately using the new calcDateDisplayStr and calcTimeDisplayStr functions