### PR TITLE
fix: NaN error in time group more

### DIFF
--- a/app/components/timeGroup/timeGroupMore/utils/calcTimeGroupMoreData.tsx
+++ b/app/components/timeGroup/timeGroupMore/utils/calcTimeGroupMoreData.tsx
@@ -1,6 +1,6 @@
 import { deepCopy, MAX_TIME, OUT_OF_TIME, WIN_CONDITION } from "../../../../utils/consts";
 import { T_DATA_KEYS, getUpgradeDataFromJSON } from '../../../../utils/getDataFromJSON';
-import { T_TimeGroup, T_Stockpiles, T_ProductionRates, T_Levels, T_PremiumInfo, T_GameState, T_ProductionSettings, } from "../../../../utils/types";
+import { T_TimeGroup, T_Stockpiles, T_ProductionRates, T_Levels, T_PremiumInfo, T_GameState } from "../../../../utils/types";
 
 import { T_MoreData, T_ResourceColours } from "./types";
 
@@ -102,7 +102,7 @@ function calcTimeIDProductionIsDone(spendRemaining : T_ResourceColours, rates : 
             ...attrs,
             [key]: projected < goal ? 
                     -1
-                    : current > goal ?
+                    : current >= goal ?
                         0
                         : Math.round((goal - current) / rate) + timeID
         }


### PR DESCRIPTION
Bug:
The time group's "more" panel was sometimes displaying "NaN NaN:NaN" instead of a finish time, "done" or "-".

Cause:
The function calculating the time ID when production would be complete was checking for `current > goal`. When goal and current were both 0, the logical test would fail, so it would proceed to the next step: dividing 0 by the production rate, hence NaN.

`current >= goal` means it correctly returns 0, which the "more" panel displays correctly.