### PR TITLE
feat: autosave

### DIFF
--- a/app/components/forms/gameState/subcomponents/formSetMode.tsx
+++ b/app/components/forms/gameState/subcomponents/formSetMode.tsx
@@ -7,7 +7,7 @@ import { PlanMode, T_PlanModeKit } from "@/app/utils/usePlanMode";
 import { Button } from "../../subcomponents/buttons";
 
 
-interface I_ModeSetter extends T_PlanModeKit{
+interface I_ModeSetter extends Pick<T_PlanModeKit, "mode" | "setMode">{
     close : () => void,
 }
 

--- a/app/components/forms/load.tsx
+++ b/app/components/forms/load.tsx
@@ -2,13 +2,15 @@ import { useId, useState } from 'react';
 
 import Modal, { ModalSubmitButton, ModalFieldsWrapper, I_Modal } from '../subcomponents/modal';
 import { SelectWithLabel, T_OptionData } from './subcomponents/select';
+import { Button } from './subcomponents/buttons';
 
 
 interface I_PropsModalLoad extends Pick<I_Modal, "closeModal"> {
     loadInputs : (str : string) => void,
     loadOptions : () => T_OptionData[] | null,
+    reset : () => void,
 }
-export default function ModalLoad({closeModal, loadInputs, loadOptions} 
+export default function ModalLoad({closeModal, loadInputs, loadOptions, reset} 
     : I_PropsModalLoad)
     : JSX.Element {
 
@@ -28,6 +30,7 @@ export default function ModalLoad({closeModal, loadInputs, loadOptions}
         closeModal();
     }
 
+    const ResetBtn = <ResetButton handleClick={() => { reset(); closeModal(); }} />
     const id = useId();
     return (
         <Modal 
@@ -35,9 +38,12 @@ export default function ModalLoad({closeModal, loadInputs, loadOptions}
             closeModal={closeModal}
             >
             { options === null ?
+                <>
                 <ModalFieldsWrapper>
                     <p>There are no saved plans</p>
                 </ModalFieldsWrapper>
+                { ResetBtn }
+                </>
                 :
                 <form onSubmit={() => handleSubmit()}>
                     <ModalFieldsWrapper>
@@ -53,10 +59,25 @@ export default function ModalLoad({closeModal, loadInputs, loadOptions}
                             />
                         </div>
                     </ModalFieldsWrapper>
-                    <ModalSubmitButton label={"load"} extraCSS={''} disabled={false} />
+                    <div className={"flex justify-between"}>
+                        <ModalSubmitButton label={"load"} extraCSS={''} disabled={false} />
+                        { ResetBtn }
+                    </div>
                 </form>
             }
+
         </Modal>
     )
+}
+
+function ResetButton({handleClick} : { handleClick : () => void }){
+    return  <Button 
+                size={"twin"}
+                colours={'warning'}
+                htmlType={'button'}
+                onClick={handleClick}
+                >
+                reset all
+            </Button>
 }
 

--- a/app/utils/useGameStateModal.tsx
+++ b/app/utils/useGameStateModal.tsx
@@ -21,7 +21,7 @@ export default function useGameStateModal({gameState, setGameState}
     : I_UseGameStateModal)
     : T_UseGameStateModalOutput {
 
-    const [showGameStateModal, setShowGameStateModal] = useState<boolean>(true);
+    const [showGameStateModal, setShowGameStateModal] = useState<boolean>(false);
 
     return {
         isVisible: showGameStateModal,

--- a/app/utils/usePlanMode.tsx
+++ b/app/utils/usePlanMode.tsx
@@ -1,4 +1,4 @@
-import { useState, SetStateAction, Dispatch } from "react";
+import { useState } from "react";
 
 export enum PlanMode {
     "active",
@@ -8,17 +8,35 @@ export enum PlanMode {
 export type T_PlanModeKit = {
     mode : PlanMode | null,
     setMode: (data : PlanMode | null) => void,
+    reset: () => void,
 }
 
 export function usePlanMode(){
-    const [mode, setMode] = useState<PlanMode | null>(null);
+    const REMEMBER_MODE_KEY = "lastUsedMode";
+
+    const [mode, setMode] = useState<PlanMode | null>(loadMode());
 
     function updateMode(data : PlanMode | null){
         setMode(data);
+        localStorage.setItem(REMEMBER_MODE_KEY, JSON.stringify(data)); 
+    }
+
+    function loadMode(){
+        const JSONStr = localStorage.getItem(REMEMBER_MODE_KEY);
+        if(JSONStr === null){
+            return null;
+        }
+        const parsed = JSON.parse(JSONStr);
+        return parsed;
+    }
+
+    function reset(){
+        updateMode(null);
     }
 
     return {
         mode,
-        setMode : updateMode
+        setMode : updateMode,
+        reset
     }
 }

--- a/app/utils/usePlanner.tsx
+++ b/app/utils/usePlanner.tsx
@@ -9,62 +9,169 @@ import { calcTimeGroups } from './calcTimeGroups';
 import { T_TimeGroup, T_OfflinePeriod, T_GameState, T_Action, T_ProductionSettingsNow } from './types';
 
 
+type T_InitData = {
+  gameState : T_GameState,
+  actions : T_Action[],
+  offlinePeriods : T_OfflinePeriod[],
+  prodSettingsNow : null | T_ProductionSettingsNow,
+}
+
+
 export default function usePlanner(){
-    const [gameState, setGameState] = useState<T_GameState>(defaultGameState);
-    const [offlinePeriods, setOfflinePeriods] = useState<T_OfflinePeriod[]>([]);
-    const [actions, setActions] = useState<T_Action[]>(defaultActionsList());
-    const [prodSettingsNow, setProdSettingsNow] = useState<T_ProductionSettingsNow | null>(null);
 
-    const planData = calcPlanData({ gameState, actions, offlinePeriods, prodSettingsNow });
-    const [purchaseData, setPurchaseData] = useState(planData?.purchaseData);
-    const [switchData, setSwitchData] = useState(planData?.switchData);
-    const [prodSettingsBeforeNow, setProdSettingsBeforeNow] = useState(planData?.productionSettingsBeforeNow);
-    const [timeData, setTimeData] = useState(planData?.timeData);
+  const defaultInitData : T_InitData = {
+    gameState: defaultGameState,
+    offlinePeriods: [],
+    actions: defaultActionsList(),
+    prodSettingsNow: null
+  }
 
-    useEffect(() => {
-        let updatedPlan = calcPlanData({ gameState, actions, offlinePeriods, prodSettingsNow });
-        if(updatedPlan === null){
-          return;
-        }
-        setPurchaseData(updatedPlan.purchaseData);
-        setSwitchData(updatedPlan.switchData);
-        setProdSettingsBeforeNow(updatedPlan.productionSettingsBeforeNow);
-        setTimeData(updatedPlan.timeData);
-      }, [prodSettingsNow, actions, gameState, offlinePeriods]);
-    
-    const timeIDGroups : T_TimeGroup[] | null = purchaseData === undefined || switchData === undefined || timeData === undefined ?
-        null 
-        : calcTimeGroups({purchaseData, switchData, timeData});
+  const {
+    autosave,
+    deleteAutosave,
+    autoload
+  } = autosaveKit();
 
-    function updateGameState(data : T_GameState){
-      setGameState(data)
+  const autosaveData = autoload();
+  const initData : T_InitData = autosaveData === null ?
+    defaultInitData
+    : autosaveData;
+
+  console.log(autosaveData);
+
+
+  const [gameState, setGameState] = useState<T_GameState>(initData.gameState);
+  const [offlinePeriods, setOfflinePeriods] = useState<T_OfflinePeriod[]>(initData.offlinePeriods);
+  const [actions, setActions] = useState<T_Action[]>(initData.actions);
+  const [prodSettingsNow, setProdSettingsNow] = useState<T_ProductionSettingsNow | null>(initData.prodSettingsNow);
+
+  const planData = calcPlanData({ gameState, actions, offlinePeriods, prodSettingsNow });
+  const [purchaseData, setPurchaseData] = useState(planData?.purchaseData);
+  const [switchData, setSwitchData] = useState(planData?.switchData);
+  const [prodSettingsBeforeNow, setProdSettingsBeforeNow] = useState(planData?.productionSettingsBeforeNow);
+  const [timeData, setTimeData] = useState(planData?.timeData);
+
+
+  useEffect(() => {
+    const updatedPlan = calcPlanData({ gameState, actions, offlinePeriods, prodSettingsNow });
+    if(updatedPlan === null){
+      return;
+    }
+    setPurchaseData(updatedPlan.purchaseData);
+    setSwitchData(updatedPlan.switchData);
+    setProdSettingsBeforeNow(updatedPlan.productionSettingsBeforeNow);
+    setTimeData(updatedPlan.timeData);
+  }, [prodSettingsNow, actions, gameState, offlinePeriods]);
+  
+
+  const timeIDGroups : T_TimeGroup[] | null = purchaseData === undefined || switchData === undefined || timeData === undefined ?
+    null 
+    : calcTimeGroups({purchaseData, switchData, timeData});
+
+
+  function updateGameState(data : T_GameState){
+    setGameState(data);
+    autosave({
+      gameState: data,
+      offlinePeriods,
+      actions,
+      prodSettingsNow
+    });
+  }
+
+
+  function updateOfflinePeriods(data : T_OfflinePeriod[]){
+    setOfflinePeriods(data);
+    autosave({
+      gameState,
+      offlinePeriods: data,
+      actions,
+      prodSettingsNow
+    });
+  }
+
+
+  function updateActions(data : T_Action[]){
+    setActions(data);
+    autosave({
+      gameState,
+      offlinePeriods,
+      actions: data,
+      prodSettingsNow
+    });
+  }
+
+
+  function updateProdSettingsNow(data : T_ProductionSettingsNow | null){
+    setProdSettingsNow(data);
+    autosave({
+      gameState,
+      offlinePeriods,
+      actions,
+      prodSettingsNow: data
+    });
+  }
+
+
+  function reset(){
+    setGameState(defaultInitData.gameState);
+    setOfflinePeriods(defaultInitData.offlinePeriods);
+    setActions(defaultInitData.actions);
+    setProdSettingsNow(defaultInitData.prodSettingsNow);
+    deleteAutosave();
+  }
+
+
+  return {
+    gameState, 
+    setGameState: updateGameState,
+    offlinePeriods, 
+    setOfflinePeriods: updateOfflinePeriods,
+    actions, 
+    setActions: updateActions,
+    prodSettingsNow,
+    setProdSettingsNow: updateProdSettingsNow,
+    purchaseData,
+    switchData,
+    timeIDGroups,
+    prodSettingsBeforeNow,
+    reset,
+    loadedFromAutosave: autosaveData !== null,
+  }
+}
+
+
+function autosaveKit(){
+  const AUTOSAVE_KEY = "autoSaveData";
+
+  function autosave(data : T_InitData){
+    localStorage.setItem(AUTOSAVE_KEY, JSON.stringify(data)); 
+  }
+
+  function autoload(){
+    let JSONStr = localStorage.getItem(AUTOSAVE_KEY);
+    if(JSONStr === null){
+        return null;
     }
 
-    function updateOfflinePeriods(data : T_OfflinePeriod[]){
-      setOfflinePeriods(data);
+    let parsed = JSON.parse(JSONStr) as T_InitData;
+    parsed.gameState.startTime = new Date(parsed.gameState.startTime);
+    parsed.gameState.timeEntered = new Date(parsed.gameState.startTime);
+
+    if(parsed.offlinePeriods === undefined){
+      parsed.offlinePeriods = []
     }
 
-    function updateProdSettingsNow(data : T_ProductionSettingsNow | null){
-      setProdSettingsNow(data);
-    }
+    return parsed;
+  }
 
-    function updateActions(data : T_Action[]){
-      setActions(data);
-    }
+  function deleteAutosave(){
+      localStorage.removeItem(AUTOSAVE_KEY);
+  }
 
-
-    return {
-        gameState, 
-        setGameState: updateGameState,
-        offlinePeriods, 
-        setOfflinePeriods: updateOfflinePeriods,
-        actions, 
-        setActions: updateActions,
-        prodSettingsNow,
-        setProdSettingsNow: updateProdSettingsNow,
-        purchaseData,
-        switchData,
-        timeIDGroups,
-        prodSettingsBeforeNow
-    }
+  return {
+    autosave,
+    deleteAutosave,
+    autoload,
+  }
 }

--- a/app/utils/useSaveAndLoad.tsx
+++ b/app/utils/useSaveAndLoad.tsx
@@ -1,4 +1,4 @@
-import {useState, Dispatch, SetStateAction} from 'react';
+import { useState } from 'react';
 
 import { T_OfflinePeriod, T_GameState, T_Action, T_PremiumInfo, T_ModalWithToggle } from './types';
 
@@ -10,6 +10,7 @@ interface I_SaveAndLoad {
     setOfflinePeriods : (data : T_OfflinePeriod[]) => void,
     gameState : T_GameState,
     setGameState : (data : T_GameState) => void,
+    reset : () => void,
 }
 
 type T_LocalStorage = {
@@ -22,7 +23,7 @@ type T_SaveAndLoadOutput = {
     save : T_ModalWithToggle,
     load : T_ModalWithToggle
 }
-export default function useSaveAndLoad({actions, setActions, offlinePeriods, setOfflinePeriods, gameState, setGameState }
+export default function useSaveAndLoad({actions, setActions, offlinePeriods, setOfflinePeriods, gameState, setGameState, reset }
     : I_SaveAndLoad)
     : T_SaveAndLoadOutput {
 
@@ -53,7 +54,7 @@ export default function useSaveAndLoad({actions, setActions, offlinePeriods, set
 
         if(loadedJSONStr === null){
             // TODO: error handling: can't find value
-            console.log(`${keySuffix} not found :(`)
+            //console.log(`${keySuffix} not found :(`)
             return;
         }
 
@@ -132,7 +133,8 @@ export default function useSaveAndLoad({actions, setActions, offlinePeriods, set
             action: loadInputs,
             data: {
                 displayStr: "load",
-                loadOptions
+                loadOptions,
+                reset
             }
         }
     }


### PR DESCRIPTION
Autosave's purpose is to "keep things where you left them" if the user closes their browser window during their planning.

Features:
* Website now "remembers" where you were when you left it, in terms of game status, offline periods and upgrades/switches
* This includes the input mode: users who have already selected an input mode will not be prompted to select one again on their return
* If a user wishes to wipe everything to factory defaults, there's a button in the "load" modal

Difference between this and the existing save/load feature:
* Purpose. Autosave is about not annoying users by making their work vanish; save/load allows users to try out different plans and switch between them.
* User interaction. Autosave works in the backgorund; save/load is a decision made by the user.
* Content. Autosave saves everything except "now" production settings; save/load discards stockpiles, levels and time remaining