### PR TITLE
fix: removed use of toSorted

### DIFF
--- a/app/utils/offlinePeriodHelpers.tsx
+++ b/app/utils/offlinePeriodHelpers.tsx
@@ -73,7 +73,8 @@ export function printOfflineTime(dhm : T_TimeOfflinePeriod) : string{
 
 
 export function calcSortedOfflinePeriods(offlinePeriods : T_OfflinePeriod[]){
-    return offlinePeriods.toSorted((a, b) => {
+    let sorted : T_OfflinePeriod[] = deepCopy(offlinePeriods);
+    return sorted.sort((a, b) => {
         const aStart = convertOfflineTimeToNumber(a.start);
         const bStart = convertOfflineTimeToNumber(b.start);
 

--- a/app/utils/usePlanner.tsx
+++ b/app/utils/usePlanner.tsx
@@ -37,9 +37,6 @@ export default function usePlanner(){
     defaultInitData
     : autosaveData;
 
-  console.log(autosaveData);
-
-
   const [gameState, setGameState] = useState<T_GameState>(initData.gameState);
   const [offlinePeriods, setOfflinePeriods] = useState<T_OfflinePeriod[]>(initData.offlinePeriods);
   const [actions, setActions] = useState<T_Action[]>(initData.actions);


### PR DESCRIPTION
Array.toSorted() requires ES2023. While it's supported by all current non-IE browsers, using such a new feature could exclude users unnecessarily, so I've replaced it.

(Removed an errant console.log while I was at it)