### PR TITLE
fix: game status modal auto-appearance

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -43,14 +43,13 @@ export default function Home() {
   const { save : saveModal, load: loadModal } = useSaveAndLoad({actions, setActions, offlinePeriods, setOfflinePeriods, gameState, setGameState, reset});
 
   const [hasHandledInitialModal, setHasHandledInitialModal] = useState(false);
-  if(!hasHandledInitialModal){
+  if(!hasHandledInitialModal && loadedFromAutosave !== null){
     if(!loadedFromAutosave){
       gameStateModal.openModal();
     }
     setHasHandledInitialModal(true);
   }
 
-  
   return (
     <main className={`${theme.emptyBg} flex justify-center min-h-screen`}>
 

--- a/app/utils/usePlanner.tsx
+++ b/app/utils/usePlanner.tsx
@@ -38,7 +38,7 @@ export default function usePlanner(){
   const [prodSettingsBeforeNow, setProdSettingsBeforeNow] = useState(planData?.productionSettingsBeforeNow);
   const [timeData, setTimeData] = useState(planData?.timeData);
 
-  const [loadedFromAutosave, setLoadedFromAutosave] = useState(false);
+  const [loadedFromAutosave, setLoadedFromAutosave] = useState<boolean | null>(null);
 
   const {
     autosave,
@@ -54,6 +54,9 @@ export default function usePlanner(){
       setActions(autoloaded.actions);
       setProdSettingsNow(autoloaded.prodSettingsNow);
       setLoadedFromAutosave(true);
+    }
+    else {
+      setLoadedFromAutosave(false);
     }
   }, [])
 


### PR DESCRIPTION
Bug:
When the page was reloaded, the game status modal was auto-appearing every time, regardless of whether the user had auto-save data or not.

Expected behaviour:
When the page is reloaded, the modal should only auto-appear for users without auto-save data.

Cause:
Recent refactoring to accommodate Next's build process resulted in a delay to when auto-save data is loaded: this now occurs in a useEffect hook and so affects the second render, not the first.

The modal's auto-appearance logic had not been updated to take the delay into account. It was checking for auto-save data on the first render, before auto-save data was loaded, so of course it never found any. Since it found no auto-save data, it auto-appeared.

Fix:
Adjusted the auto-appearance logic to wait until after loading auto-save data has been attempted.