### PR TITLE
fix: time entered (and time remaining)

### DIFF
--- a/app/components/forms/gameState/subcomponents/formActiveMode.tsx
+++ b/app/components/forms/gameState/subcomponents/formActiveMode.tsx
@@ -33,13 +33,12 @@ export default function FormActiveMode({gameState, setGameState, changeMode, wan
             handleLevelChange,
             hasAdBoost,
             toggleAdBoost,
-            timeEntered,
-            setTimeEntered,
             timeRemaining,
-            setTimeRemaining,
+            updateTimeRemaining,
+            timestamp,
+            updateTimestamp,
             controlledStockpileValue,
             updateStockpiles,
-            setStateOnChange,
         } = useActiveGameStatusForm({setGameState, gameState, closeModal});
 
     const wantBackToModeSetter = useRef<boolean | undefined>();
@@ -59,11 +58,10 @@ export default function FormActiveMode({gameState, setGameState, changeMode, wan
                     isVisible={ activePage === 1 }
                     >
                     <InputGeneral
-                        timeEntered={timeEntered}
-                        setStateOnChange={setStateOnChange}
-                        setTimeEntered={setTimeEntered}
+                        timestamp={timestamp}
+                        updateTimestamp={updateTimestamp}
                         timeRemaining={timeRemaining}
-                        setTimeRemaining={setTimeRemaining}
+                        updateTimeRemaining={updateTimeRemaining}
                         gameState={gameState}
                         handleLevelChange={handleLevelChange}
                         hasAdBoost={hasAdBoost}

--- a/app/components/forms/gameState/subcomponents/pageGeneral.tsx
+++ b/app/components/forms/gameState/subcomponents/pageGeneral.tsx
@@ -1,9 +1,5 @@
-import { Dispatch, SetStateAction } from "react";
-
-import { calcDateWithTimeDisplayStr } from '../../../../utils/dateAndTimeHelpers';
 import { capitalise } from '../../../../utils/formatting';
 
-import { Button } from '../../subcomponents/buttons';
 import FieldsetWrapper from "../../subcomponents/fieldsetWrapper";
 
 import { useTimeRemainingFieldset, I_TimeRemainingFieldset } from "../utils/useTimeRemainingFieldset";
@@ -12,16 +8,18 @@ import { InputNumberAsText, Label } from "../gameState"
 
 import AllEggs, { I_AllEggs } from "./fieldAllEggs";
 import AdBoost, { I_AdBoostInputEle } from "./fieldAdBoost";
+import Select, { SelectHours, SelectMinutes } from '../../subcomponents/select';
+import { ChangeEvent } from 'react';
 
 
-export interface I_InputGeneral extends I_TimeRemainingFieldset, I_Entered, I_AllEggs, I_AdBoostInputEle {}
-export default function InputGeneral({timeRemaining, setTimeRemaining, timeEntered, setStateOnChange, setTimeEntered, gameState, handleLevelChange, hasAdBoost, toggleAdBoost } 
+export interface I_InputGeneral extends I_TimestampFieldset, I_TimeRemainingFieldset, I_AllEggs, I_AdBoostInputEle {}
+export default function InputGeneral({timestamp, updateTimestamp, timeRemaining, updateTimeRemaining, gameState, handleLevelChange, hasAdBoost, toggleAdBoost } 
     : I_InputGeneral)
     : JSX.Element {
 
     return  <div className={"flex flex-col gap-6 mt-2"}>
-                <TimeRemainingFieldset timeRemaining={timeRemaining} setTimeRemaining={setTimeRemaining} />
-                <Entered timeEntered={timeEntered} setStateOnChange={setStateOnChange} setTimeEntered={setTimeEntered} />
+                <TimestampFieldset timestamp={timestamp} updateTimestamp={updateTimestamp}/>
+                <TimeRemainingFieldset timeRemaining={timeRemaining} updateTimeRemaining={updateTimeRemaining} />
                 <AllEggs gameState={gameState} handleLevelChange={handleLevelChange} />
                 <AdBoost hasAdBoost={hasAdBoost} toggleAdBoost={toggleAdBoost} />
             </div>
@@ -29,50 +27,51 @@ export default function InputGeneral({timeRemaining, setTimeRemaining, timeEnter
 }
 
 
-interface I_Entered {
-    timeEntered : Date, 
-    setStateOnChange : (e : React.ChangeEvent<any>, setFunction : Dispatch<SetStateAction<any>>) => void, 
-    setTimeEntered : Dispatch<SetStateAction<Date>>
+interface I_TimestampFieldset{
+    timestamp : Date, 
+    updateTimestamp : (e : ChangeEvent<HTMLSelectElement>, key : string) => void 
 }
-function Entered({timeEntered, setStateOnChange, setTimeEntered} 
-    : I_Entered)
+function TimestampFieldset({timestamp, updateTimestamp}
+    : I_TimestampFieldset)
     : JSX.Element {
 
-    timeEntered = timeEntered ?? new Date();
+    const dayID = "id_timestampDay";
 
-    return(
-        <div className={"flex items-center gap-2"}>
-            <Label htmlFor={"id_timeEntered"}>
-                Entered
-            </Label>
-            <Button 
-                htmlType={"button"}
-                onClick={() => { setTimeEntered(new Date()) }}
-                colours={"secondary"}
-                size={"inline"}
-                extraCSS={"w-min"}
-                >
-                now
-            </Button>
-            <p 
-                suppressHydrationWarning={true} 
-                className={"ml-2"}
-                >
-                { calcDateWithTimeDisplayStr(timeEntered) }
-            </p>
-            <input 
-                hidden 
-                type="datetime-local" 
-                id={"id_timeEntered"} 
-                value={`${timeEntered}`} 
-                onChange={(e) => setStateOnChange(e, setTimeEntered)}
-            />
-        </div>
-    )
+    return  <FieldsetWrapper>
+                <Label extraCSS={"font-semibold w-min px-1"} htmlFor={''} tagName={'legend'}>
+                    Status&nbsp;At
+                </Label>
+
+                <div className={"flex gap-2 w-full py-1 pl-4"}>
+                    <label htmlFor={dayID} className={"sr-only"}>day</label>
+                    <Select
+                        id={dayID}
+                        options={[
+                            { valueStr:"today", displayStr:"today" },
+                            { valueStr:"yesterday", displayStr:"yesterday" }
+                        ]}
+                        handleChange={ (e) => updateTimestamp(e, 'days') }
+                        initValue={"today"}
+                    />
+
+                    <div className={"flex"}>
+                        <SelectHours
+                            id={"id_timestampHours"}
+                            handleChange={ (e) => updateTimestamp(e, 'hours') }
+                            initValue={timestamp.getHours().toString()}
+                        />
+                        <SelectMinutes
+                            id={"id_timestampMinutes"}
+                            handleChange={ (e) => updateTimestamp(e, 'minutes') }
+                            initValue={timestamp.getMinutes().toString()}
+                        />
+                    </div>
+                </div>
+            </FieldsetWrapper>
 }
 
 
-function TimeRemainingFieldset({timeRemaining, setTimeRemaining} 
+function TimeRemainingFieldset({timeRemaining, updateTimeRemaining} 
     : I_TimeRemainingFieldset)
     : JSX.Element {
 
@@ -82,7 +81,7 @@ function TimeRemainingFieldset({timeRemaining, setTimeRemaining}
         handleChangeDays, 
         handleChangeHours, 
         handleChangeMinutes 
-    } = useTimeRemainingFieldset({timeRemaining, setTimeRemaining});
+    } = useTimeRemainingFieldset({timeRemaining, updateTimeRemaining});
 
     return (
         <FieldsetWrapper>

--- a/app/components/forms/gameState/utils/useActiveGameStatusForm.tsx
+++ b/app/components/forms/gameState/utils/useActiveGameStatusForm.tsx
@@ -1,8 +1,8 @@
-import { useState, SetStateAction } from "react";
+import { ChangeEvent, useState } from "react";
 
 import { MS_PER_MINUTE } from "@/app/utils/consts";
 import { startingLevels, startingStockpiles, startingTimeRemaining, lateGameSettings, maxLevels } from '@/app/utils/defaults';
-import { convertTimeIDToDHM, convertTimeRemainingToMinutes } from "@/app/utils/dateAndTimeHelpers";
+import { convertTimeIDToDHM, convertTimeRemainingToMinutes, validateHour, validateMinute } from "@/app/utils/dateAndTimeHelpers";
 import { T_GameState, T_TimeRemainingDHM, T_Stockpiles, T_Levels } from "@/app/utils/types";
 import { deepCopy } from '@/app/utils/utils';
 
@@ -19,11 +19,10 @@ import { calcLevelKeyValue, calcValidLevel } from "./levelSelectHelpers";
 
 type T_OutputUseGameStatusForm = 
     Pick<I_InputGeneral, 
+        "timestamp" |
+        "updateTimestamp" |
         "handleLevelChange" | 
-        "setStateOnChange" | 
-        "setTimeEntered" | 
-        "setTimeRemaining" | 
-        "timeEntered" | 
+        "updateTimeRemaining" | 
         "timeRemaining"> &
     Pick<I_InputLevelsOther, 
         "levels" | 
@@ -36,18 +35,13 @@ export function useActiveGameStatusForm({gameState, setGameState, closeModal}
     : I_StatusFormSharedProps)
     : T_OutputUseGameStatusForm {
 
-    const [timeEntered, setTimeEntered] = useState<Date>(new Date());
+    const [timestamp, setTimestamp] = useState<Date>(new Date());
     const [timeRemaining, setTimeRemaining] = useState<T_TimeRemainingDHM>(gameState === null ? startingTimeRemaining : convertTimeIDToDHM(gameState.timeRemaining))
     const [allEggsLevel, setAllEggsLevel] = useState<number>(gameState === null ? 0 : gameState.premiumInfo.allEggs)
     const [stockpiles, setStockpiles] = useState<T_Stockpiles>(gameState === null ? deepCopy(startingStockpiles) : gameState.stockpiles)
     const [levels, setLevels] = useState<T_Levels>(gameState === null ? deepCopy(startingLevels) : gameState.levels)
 
     const {hasAdBoost, toggleAdBoost} = useAdBoost({gameState});
-
-
-    function setStateOnChange(e : React.ChangeEvent<any>, setFunction : React.Dispatch<SetStateAction<any>>){
-        setFunction(e.target.value);
-    }
 
     // function setToLateGame(){
     //     setTimeEntered(new Date(new Date().getTime() - 5 * 60 * 1000));
@@ -66,6 +60,74 @@ export function useActiveGameStatusForm({gameState, setGameState, closeModal}
     //     setStockpiles(lateGameSettings.stockpiles);
     //     setLevels(maxLevels);
     // }
+
+
+    function updateTimestamp(e : ChangeEvent<HTMLSelectElement>, key : string){
+        if(['minutes', 'hours', 'days'].includes(key)){
+            const newTimeValue = e.target.value;
+
+            if(key === 'days'){
+                setTimestamp(prev => {
+                    let newDate = new Date(prev.getTime());
+                    let now = new Date();
+                    if(newTimeValue === 'yesterday'){
+                        newDate.setDate(now.getDate() - 1);
+                    }
+                    else{
+                        newDate.setDate(now.getDate());
+                    }
+                    return newDate;
+                });
+            }
+            else if(key === 'hours'){
+                const newHour = validateHour(newTimeValue);
+                if(newHour !== null){
+                    setTimestamp(prev => {
+                        let newDate = new Date(prev.getTime());
+                        newDate.setHours(newHour);
+                        return newDate;
+                    })
+                }
+            }
+            else if(key === 'minutes'){
+                const minutesInt = validateMinute(newTimeValue);
+                if(minutesInt !== null){
+                    setTimestamp(prev => {
+                        let newDate = new Date(prev.getTime());
+                        newDate.setMinutes(minutesInt);
+                        return newDate;
+                    })
+                }
+            }
+        }
+    }
+
+
+    function updateTimeRemaining(newData : Partial<T_TimeRemainingDHM>){
+        let hasValidData = false;
+        let validData : Partial<T_TimeRemainingDHM> = {};
+
+        if('days' in newData){
+            validData.days = newData.days;
+            hasValidData = true;
+        }
+        if('hours' in newData){
+            validData.hours = newData.hours;
+            hasValidData = true;
+        }
+        if('minutes' in newData){
+            validData.minutes = newData.minutes;
+            hasValidData = true;
+        }
+
+        if(hasValidData){
+            setTimeRemaining(prev => { return {
+                ...prev,
+                ...validData
+            }})
+        }
+    }
+
 
     function updateStockpiles(e : React.ChangeEvent<HTMLInputElement>, key : string){
         let newStockpiles : T_Stockpiles = deepCopy(stockpiles);
@@ -112,28 +174,28 @@ export function useActiveGameStatusForm({gameState, setGameState, closeModal}
         : T_GameState {
     
         const timeRemainingAsNum : number = convertTimeRemainingToMinutes(timeRemaining);
-        const startTime : Date = calcStartTime({timeEntered, timeRemaining: timeRemainingAsNum});
+        const startTime : Date = calcStartTime({timestamp: timestamp, timeRemaining: timeRemainingAsNum});
     
-        function calcStartTime({ timeEntered, timeRemaining }
-            : Pick<T_GameState, "timeRemaining" | "timeEntered"> ) 
+        function calcStartTime({ timestamp, timeRemaining }
+            : Pick<T_GameState, "timeRemaining" | "timestamp"> ) 
             : Date {
                 
             let startedAt : Date;
             const TIME_REMAINING_AT_START = 3 * 24 * 60;
         
             if(timeRemaining === TIME_REMAINING_AT_START){
-                startedAt = timeEntered;
+                startedAt = timestamp;
             }
             else{
                 let timePassed = (TIME_REMAINING_AT_START - timeRemaining) * MS_PER_MINUTE;
-                startedAt = new Date(timeEntered.getTime() - timePassed);
+                startedAt = new Date(timestamp.getTime() - timePassed);
             }
             return startedAt;
         }
 
         return {
             startTime,
-            timeEntered,
+            timestamp,
             timeRemaining: timeRemainingAsNum,
             premiumInfo: {
                 adBoost: hasAdBoost,
@@ -149,11 +211,10 @@ export function useActiveGameStatusForm({gameState, setGameState, closeModal}
         onSubmit,
         hasAdBoost,
         toggleAdBoost,
-        timeEntered,
-        setStateOnChange,
-        setTimeEntered,
         timeRemaining,
-        setTimeRemaining,
+        updateTimeRemaining,
+        timestamp,
+        updateTimestamp,
         levels,
         handleLevelChange,
         controlledStockpileValue,

--- a/app/components/forms/gameState/utils/usePlanGameStatusForm.tsx
+++ b/app/components/forms/gameState/utils/usePlanGameStatusForm.tsx
@@ -45,7 +45,7 @@ export function usePlanGameStatusForm({gameState, setGameState, closeModal}
         const timeRemaining : number = convertTimeRemainingToMinutes(startingTimeRemaining);
         return {
             startTime,
-            timeEntered : new Date(),
+            timestamp : new Date(),
             timeRemaining,
             premiumInfo: {
                 adBoost: hasAdBoost,

--- a/app/components/forms/gameState/utils/useTimeRemainingFieldset.tsx
+++ b/app/components/forms/gameState/utils/useTimeRemainingFieldset.tsx
@@ -6,7 +6,7 @@ import { T_TimeRemainingDHM } from "@/app/utils/types";
 
 export interface I_TimeRemainingFieldset {
     timeRemaining: T_TimeRemainingDHM,
-    setTimeRemaining: React.Dispatch<React.SetStateAction<T_TimeRemainingDHM>>
+    updateTimeRemaining: (data : Partial<T_TimeRemainingDHM>) => void,
 }
 
 type T_OutputUseTimeRemainingFieldset = {
@@ -16,7 +16,7 @@ type T_OutputUseTimeRemainingFieldset = {
     handleChangeHours : (e : React.ChangeEvent<HTMLInputElement>) => void, 
     handleChangeMinutes : (e : React.ChangeEvent<HTMLInputElement>) => void, 
 }
-export function useTimeRemainingFieldset({timeRemaining, setTimeRemaining}
+export function useTimeRemainingFieldset({timeRemaining, updateTimeRemaining}
     : I_TimeRemainingFieldset)
     : T_OutputUseTimeRemainingFieldset {
 
@@ -33,19 +33,15 @@ export function useTimeRemainingFieldset({timeRemaining, setTimeRemaining}
         newDays = validateDays(newDays);
 
         if(newDays === MAX_DAYS){
-            setTimeRemaining({
+            updateTimeRemaining({
                 days: MAX_DAYS,
                 hours: 0,
                 minutes: 0
-            });
+            })
             return;
         }
-
-        setTimeRemaining(prev => {
-            return {
-                ...prev,
-                days: newDays
-            }
+        updateTimeRemaining({
+            days: newDays
         });
     }
 
@@ -81,11 +77,8 @@ export function useTimeRemainingFieldset({timeRemaining, setTimeRemaining}
         let newHours = parseInt(newHoursStr);
         newHours = validateHours(newHours);
 
-        setTimeRemaining((prev) => {
-            return {
-                ...prev,
-                hours: newHours
-            }
+        updateTimeRemaining({
+            hours: newHours
         });
     }
 
@@ -120,11 +113,8 @@ export function useTimeRemainingFieldset({timeRemaining, setTimeRemaining}
         let newMinutes = parseInt(newMinutesStr);
         newMinutes = validateMinutes(newMinutes);
 
-        setTimeRemaining((prev) => {
-            return {
-                ...prev,
-                minutes: newMinutes
-            }
+        updateTimeRemaining({
+            minutes: newMinutes
         });
     }
 

--- a/app/components/forms/subcomponents/fieldsetWrapper.tsx
+++ b/app/components/forms/subcomponents/fieldsetWrapper.tsx
@@ -6,10 +6,8 @@ export default function FieldsetWrapper({children}
     : JSX.Element {
 
     return  <fieldset 
-                className={"relative rounded-sm max-w-full w-11/12 pb-2 border border-violet-200 bg-violet-50 bg-opacity-40"}
+                className={"relative rounded-sm max-w-full w-full pb-2 border border-violet-200 bg-violet-50 bg-opacity-40"}
                 >
                 { children }
             </fieldset>
 }
-
-

--- a/app/components/sectionGameState.test.tsx
+++ b/app/components/sectionGameState.test.tsx
@@ -260,13 +260,13 @@ describe(SectionGameState, () => {
     })
 
 
-    it("renders time entered correctly", () => {
-        const timeEntered = new Date('1995-12-17T03:24:00')
+    it("renders timestamp correctly", () => {
+        const timestamp = new Date('1995-12-17T03:24:00')
         render(
             <SectionGameState   
                 gameState={ { 
                             ...defaultGameState,
-                            timeEntered
+                            timestamp: timestamp
                          }}
                 openEditForm={() => {}}
                 mode={ PlanMode.active }

--- a/app/components/sectionGameState.tsx
+++ b/app/components/sectionGameState.tsx
@@ -43,7 +43,7 @@ function TimeAndPremiumStatus({gameState, mode}
                 { mode === PlanMode.active ?
                 <>
                 <GridRowWrapper title={"Updated"}>
-                    <dd suppressHydrationWarning={true}>{calcDateWithTimeDisplayStr(gameState.timeEntered)}</dd>
+                    <dd suppressHydrationWarning={true}>{calcDateWithTimeDisplayStr(gameState.timestamp)}</dd>
                 </GridRowWrapper>
 
                 <GridRowWrapper title={"Remaining"}>

--- a/app/components/sectionOfflinePeriods.test.tsx
+++ b/app/components/sectionOfflinePeriods.test.tsx
@@ -26,7 +26,7 @@ describe(SectionOfflinePeriods, () => {
                 offlinePeriods={[offlinePeriodOvernight]}
                 gameState={ {
                     ...defaultGameState,
-                    timeEntered: new Date('1995-12-17T03:24:00'),
+                    timestamp: new Date('1995-12-17T03:24:00'),
                     startTime: new Date('1995-12-17T03:24:00')
                 } }
                 openModal={() => {}}

--- a/app/utils/dateAndTimeHelpers.tsx
+++ b/app/utils/dateAndTimeHelpers.tsx
@@ -93,6 +93,28 @@ export function calcTimeDisplayStr(myDate : Date) : string {
 }
 
 
+export function validateHour(data : string){
+    const asInt = parseInt(data);
+    if(
+        asInt === undefined ||
+        asInt < 0 ||
+        asInt > 23
+    ){
+        return null;
+    }
+    return asInt;
+}
 
+export function validateMinute(data : string){
+    const asInt = parseInt(data);
+    if(
+        asInt === undefined ||
+        asInt < 0 ||
+        asInt > 59
+    ){
+        return null;
+    }
+    return asInt;
+}
 
 

--- a/app/utils/defaults.tsx
+++ b/app/utils/defaults.tsx
@@ -46,7 +46,7 @@ export const startingLevels : T_Levels = {
 }
 
 export const defaultGameState : T_GameState = {
-    timeEntered : new Date(),
+    timestamp : new Date(),
     startTime : new Date(),
     timeRemaining : MAX_TIME,
     premiumInfo :  {

--- a/app/utils/types.tsx
+++ b/app/utils/types.tsx
@@ -1,7 +1,7 @@
 import { SetStateAction, Dispatch } from "react";
 
 export type T_GameState = {
-    timeEntered : Date,
+    timestamp : Date,
     startTime : Date,
     timeRemaining : number,
     premiumInfo : T_PremiumInfo,

--- a/app/utils/usePlanner.tsx
+++ b/app/utils/usePlanner.tsx
@@ -7,7 +7,6 @@ import { defaultActionsList, defaultGameState } from './defaults';
 import calcPlanData from './calcPlanData';
 import { calcTimeGroups } from './calcTimeGroups';
 import { T_TimeGroup, T_OfflinePeriod, T_GameState, T_Action, T_ProductionSettingsNow } from './types';
-// import { isRunningOnClient } from "./utils";
 
 
 type T_InitData = {
@@ -165,7 +164,7 @@ function autosaveKit(){
 
     let parsed = JSON.parse(JSONStr) as T_InitData;
     parsed.gameState.startTime = new Date(parsed.gameState.startTime);
-    parsed.gameState.timeEntered = new Date(parsed.gameState.startTime);
+    parsed.gameState.timestamp = new Date(parsed.gameState.startTime);
 
     if(parsed.offlinePeriods === undefined){
       parsed.offlinePeriods = []


### PR DESCRIPTION
Problem:
Delays at any point in the form-filling process could throw off the link between "timeEntered" and the time at which the entered values for time remaining, stockpiles and levels were correct, making a nonsense of offline periods and estimated purchase times.

The previous solution - displaying "time entered" and a button to update it to "now" - was inadequate. How would the user know that "time entered" actually means "time at which these values were correct"? What if they'd intentionally entered slightly old data and needed an /earlier/ time?

Solution:
Replaced the old form inputs with a fieldset labelled "Status At" which contains selects for the hour, minute and - to support the date rolling over - "today or yesterday".

* Initialises to "now", so players promptly entering current data lose nothing, they can skip over the fieldset as they skipped over the button
* Players wishing to enter older data can now do so (within 24hrs).
* For unintentional delays, hopefully the fieldset better conveys its purpose and stands out a bit more

Also:
* timeEntered renamed to "timestamp" in the code to more accurately convey its purpose
* Refactored the hook for the active game status form to pass out a closure for setting timeRemaining instead of the set state action(*) and removed a closure used only by the old timeEntered