### PR TITLE
update: changed phrasing for clarity

### DIFF
--- a/app/components/forms/gameState/subcomponents/pageGeneral.tsx
+++ b/app/components/forms/gameState/subcomponents/pageGeneral.tsx
@@ -39,7 +39,7 @@ function TimestampFieldset({timestamp, updateTimestamp}
 
     return  <FieldsetWrapper>
                 <Label extraCSS={"font-semibold w-min px-1"} htmlFor={''} tagName={'legend'}>
-                    Status&nbsp;At
+                    Timestamp
                 </Label>
 
                 <div className={"flex gap-2 w-full py-1 pl-4"}>


### PR DESCRIPTION
The timestamp field was previously labelled "Status at". At the time that made sense, but looking at it just now I was pretty confused and I'm the one who chose that label, so what hope does anyone else have?

Renamed to "Timestamp".