### PR TITLE
formatting: changed "empty bg" to match toolbars

### DIFF
--- a/app/utils/formatting.tsx
+++ b/app/utils/formatting.tsx
@@ -5,7 +5,7 @@ export const theme = {
     mainAsBg: "bg-neutral-100",
     mainAsBorder: "border-neutral-100",
     borderOnMain: "border-neutral-200",
-    emptyBg: "bg-neutral-400",
+    emptyBg: "bg-neutral-100",
     plannerHeaderFooterBgAndText: "bg-neutral-600 text-white",
     headingBgAndText: "bg-neutral-500 text-white",
 


### PR DESCRIPTION
Decided that the darker "empty" space around the app looked a bit old fashioned, so changed it to match the toolbars, leaving the panels "floating" in the middle.