### PR TITLE
fix: Next config for build and dev

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,7 @@
 const nextConfig = {
     output: 'export',
     distDir: 'dist',
-    assetPrefix: "https://alex-symonds.github.io/ialitplanner/"
+    basePath: '/ialitplanner'
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
Next's default assuption is that it's running in the root folder of the server, so it sets its paths accordingly. I'm hosting it in a subfolder, which resulted in 404 on all the assets.

Initially I fixed this by setting "assetPrefix" in the config, but while that resolved the issue in the live/built website, it had the opposite effect on the dev version.

I've now found a better solution: the "basePath" config parameter. With this set, both live/built and dev versions can find the files.