### PR TITLE
fix: formatting of <select> in Firefox

### DIFF
--- a/app/components/forms/subcomponents/select.tsx
+++ b/app/components/forms/subcomponents/select.tsx
@@ -14,8 +14,14 @@ export default function Select({id, selectExtraCSS, options, handleChange, initV
     : JSX.Element {
 
     initValue = initValue === null ? undefined : initValue;
+    const isFirefox = navigator.userAgent.indexOf("Firefox") > -1;
+    const firefoxPadding = isFirefox ? "px-[0.3125rem]" : "px-[0.0625rem]";
 
-    return  <select id={id} onChange={(e) => handleChange(e)} defaultValue={initValue} className={`border border-neutral-300 rounded-sm ${selectExtraCSS}`}>
+    return  <select 
+                id={id} 
+                onChange={(e) => handleChange(e)} 
+                defaultValue={initValue} 
+                className={`border border-neutral-300 bg-white py-0.5 rounded-sm ${firefoxPadding} ${selectExtraCSS ?? ''}`}>
             {
                 options.map( (ele, idx) => {
                     return <Option key={idx} valueStr={ele.valueStr} displayStr={ele.displayStr} />
@@ -96,15 +102,17 @@ export function SelectMinutes({id, handleChange, initValue}
 }
 
 
-
-
 export type T_OptionData = {
     valueStr : string,
     displayStr : string   
 }
-
 function Option({valueStr, displayStr} : T_OptionData){
     return (
-        <option value={valueStr}>{displayStr}</option>
+        <option 
+            className={"font-sans"}
+            value={valueStr}
+            >
+            {displayStr}
+        </option>
     )
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -18,10 +18,4 @@
 
 body {
   color: rgb(var(--foreground-rgb));
-  /* background: linear-gradient(
-      to bottom,
-      transparent,
-      rgb(var(--background-end-rgb))
-    )
-    rgb(var(--background-start-rgb)); */
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 /** @type {import('tailwindcss').Config} */
-const colors = require('tailwindcss/colors');
+const defaultTheme = require('tailwindcss/defaultTheme');
 
 module.exports = {
   content: [
@@ -8,6 +8,9 @@ module.exports = {
     './app/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
+    fontFamily: {
+      'sans': ['Inter', ...defaultTheme.fontFamily.sans],
+    },
     extend: {
       backgroundImage: {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',


### PR DESCRIPTION
Problems in Firefox:
1. Select was grey, which didn't offer enough contrast with the modal's background colour
2. Options did not inherit the site's main sans-serif font and instead displayed as a serif font, which looked out of place
3. The text inside the select was bunched up right against the left border

Items 1 and 2 were straightforward fixes.

Item 3 was less so. The select text looked ok in Chrome and Safari to begin with, so increasing the padding for Firefox would make it too much for both of those browsers, so a Firefox-only class was needed.